### PR TITLE
Allow using KafkaProperties for configuration

### DIFF
--- a/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStore.java
+++ b/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStore.java
@@ -240,6 +240,17 @@ public class ReactorKafkaEventStore implements EventStore {
 
     @Configuration
     static class Config {
+        private static final String KEY_SERIALIZER_CLASS = "org.apache.kafka.common.serialization.UUIDSerializer";
+        private static final String VALUE_SERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroSerializer";
+
+        private static final String KEY_DESERIALIZER_CLASS = "org.apache.kafka.common.serialization.UUIDDeserializer";
+        private static final String VALUE_DESERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
+
+        private static final String VALUE_SUBJECT_NAME_STRATEGY_CONFIG = "value.subject.name.strategy";
+        private static final String VALUE_SUBJECT_NAME_STRATEGY = "io.confluent.kafka.serializers.subject.RecordNameStrategy";
+
+        private static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
+
         @Bean
         KafkaSender<UUID, SpecificRecord> kafkaSender(SenderOptions<UUID, SpecificRecord> senderOptions) {
             return KafkaSender.create(senderOptions);
@@ -249,12 +260,9 @@ public class ReactorKafkaEventStore implements EventStore {
         SenderOptions<UUID, SpecificRecord> kafkaSenderOptions(KafkaProperties properties) {
             var props = properties.buildProducerProperties(null);
 
-            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                    "org.apache.kafka.common.serialization.UUIDSerializer");
-            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                    "io.confluent.kafka.serializers.KafkaAvroSerializer");
-            props.put("value.subject.name.strategy",
-                    "io.confluent.kafka.serializers.subject.RecordNameStrategy");
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KEY_SERIALIZER_CLASS);
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, VALUE_SERIALIZER_CLASS);
+            props.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
 
             return SenderOptions.create(props);
         }
@@ -266,12 +274,10 @@ public class ReactorKafkaEventStore implements EventStore {
             props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
             props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
             props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-                    "org.apache.kafka.common.serialization.UUIDDeserializer");
-            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                    "io.confluent.kafka.serializers.KafkaAvroDeserializer");
-            props.put("specific.avro.reader", "true");
-            props.put("value.subject.name.strategy", "io.confluent.kafka.serializers.subject.RecordNameStrategy");
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KEY_DESERIALIZER_CLASS);
+            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, VALUE_DESERIALIZER_CLASS);
+            props.putIfAbsent(SPECIFIC_AVRO_READER_CONFIG, "true");
+            props.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
 
             return ReceiverOptions.create(props);
         }

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsConfigurationTest.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsConfigurationTest.java
@@ -27,7 +27,10 @@ package tech.kage.event.kafka.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 
 /**
  * Tests of Kafka Streams configuration.
@@ -42,16 +45,21 @@ class KafkaStreamsConfigurationTest {
     void createsKafkaStreamsConfig() {
         // Given
         var applicationId = "test-app";
-        var bootstrapServers = "localhost:9092";
-        var schemaRegistryUrl = "http://localhost:8989";
 
+        var kafkaProperties = new KafkaProperties();
+
+        kafkaProperties.setBootstrapServers(List.of("localhost:9092"));
+        kafkaProperties.getProperties().put("schema.registry.url", "http://localhost:8989");
+
+        var expectedBootstrapServers = "localhost:9092";
+        var expectedSchemaRegistryUrl = "http://localhost:8989";
         var expectedKeySerde = "org.apache.kafka.common.serialization.Serdes$UUIDSerde";
         var expectedValueSerde = "io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde";
         var expectedProcessingGuarantee = "exactly_once_v2";
         var expectedValueSubjectNameStrategy = "io.confluent.kafka.serializers.subject.RecordNameStrategy";
 
         // When
-        var kStreamsConfig = config.kStreamsConfig(applicationId, bootstrapServers, schemaRegistryUrl);
+        var kStreamsConfig = config.kStreamsConfig(kafkaProperties, applicationId);
 
         // Then
         var configurationProperties = kStreamsConfig.asProperties();
@@ -62,11 +70,11 @@ class KafkaStreamsConfigurationTest {
 
         assertThat(configurationProperties.get("bootstrap.servers"))
                 .describedAs("bootstrap servers")
-                .isEqualTo(bootstrapServers);
+                .isEqualTo(expectedBootstrapServers);
 
         assertThat(configurationProperties.get("schema.registry.url"))
                 .describedAs("schema registry url")
-                .isEqualTo(schemaRegistryUrl);
+                .isEqualTo(expectedSchemaRegistryUrl);
 
         assertThat(configurationProperties.get("default.key.serde"))
                 .describedAs("key serde")

--- a/tech.kage.event.postgres/src/main/java/module-info.java
+++ b/tech.kage.event.postgres/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module tech.kage.event.postgres {
     requires tech.kage.event;
 
     requires spring.beans;
+    requires spring.boot.autoconfigure;
     requires spring.context;
     requires spring.core;
 

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/AbstractPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/AbstractPostgresEventStoreIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2023, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.test.context.ActiveProfiles;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import tech.kage.event.Event;
+
+/**
+ * Integration tests for {@link PostgresEventStore}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+abstract class AbstractPostgresEventStoreIT {
+    // UUT
+    @Autowired
+    PostgresEventStore eventStore;
+
+    @Autowired
+    DatabaseClient databaseClient;
+
+    @Autowired
+    Deserializer<Object> kafkaAvroDeserializer;
+
+    @Configuration
+    @EnableAutoConfiguration
+    @Import(PostgresEventStore.class)
+    static class TestConfiguration {
+        private static final String DESERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
+
+        @Bean
+        Deserializer<Object> kafkaAvroDeserializer(@Value("${schema.registry.url}") String schemaRegistryUrl) {
+            var deserializerConfig = Map.of(
+                    "value.subject.name.strategy", "io.confluent.kafka.serializers.subject.RecordNameStrategy",
+                    "specific.avro.reader", true,
+                    "schema.registry.url", schemaRegistryUrl);
+
+            var kafkaAvroDeserializer = getDeserializerInstance();
+            kafkaAvroDeserializer.configure(deserializerConfig, false);
+
+            return kafkaAvroDeserializer;
+        }
+
+        /**
+         * Constructs a new Kafka Avro Deserializer instance. Uses reflection because
+         * {@code kafka-avro-serializer} dependency is not compatible with
+         * {@code module-info.java} (split package).
+         * 
+         * @return new Kafka Avro Serializer instance
+         */
+        @SuppressWarnings("unchecked")
+        private Deserializer<Object> getDeserializerInstance() {
+            try {
+                var ctor = Class.forName(DESERIALIZER_CLASS).getConstructor();
+
+                return (Deserializer<Object>) ctor.newInstance();
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Unable to instantiate deserializer " + DESERIALIZER_CLASS, e);
+            }
+        }
+    }
+
+    @BeforeEach
+    void setUp(@Value("classpath:/test-data/events/ddl.sql") Resource ddl) throws IOException {
+        databaseClient
+                .sql(ddl.getContentAsString(StandardCharsets.UTF_8))
+                .fetch()
+                .rowsUpdated()
+                .block();
+    }
+
+    @Test
+    void savesEventInDatabase() {
+        // Given
+        var topic = "test_events";
+        var key = UUID.randomUUID();
+        var payload = TestPayload.newBuilder().setText("test payload").build();
+        var event = Event.from(key, payload);
+
+        var eventCount = databaseClient
+                .sql("SELECT count(*) FROM events.test_events")
+                .fetch()
+                .one()
+                .map(row -> row.get("count"));
+
+        StepVerifier
+                .create(eventCount)
+                .expectNext(Long.valueOf(0))
+                .as("empty events table at test start")
+                .verifyComplete();
+
+        // When
+        eventStore.save(topic, event).block();
+
+        // Then
+        var retrievedEvent = databaseClient
+                .sql("SELECT * FROM events.test_events")
+                .fetch()
+                .one()
+                .flatMap(this::toEvent);
+
+        StepVerifier
+                .create(retrievedEvent)
+                .expectNext(event)
+                .as("finds stored event with the same data")
+                .verifyComplete();
+    }
+
+    @Test
+    void returnsStoredEvent() {
+        // Given
+        var topic = "test_events";
+        var key = UUID.randomUUID();
+        var payload = TestPayload.newBuilder().setText("test payload").build();
+        var event = Event.from(key, payload);
+
+        // When
+        var storedEvent = eventStore.save(topic, event);
+
+        // Then
+        StepVerifier
+                .create(storedEvent)
+                .expectNext(event)
+                .as("returns stored event")
+                .verifyComplete();
+    }
+
+    private Mono<Event<?>> toEvent(Map<String, Object> row) {
+        var key = (UUID) row.get("key");
+        var data = (ByteBuffer) row.get("data");
+        var timestamp = (OffsetDateTime) row.get("timestamp");
+
+        return Mono
+                .just(data.array())
+                .publishOn(Schedulers.boundedElastic())
+                .map(bytes -> kafkaAvroDeserializer.deserialize(null, bytes))
+                .map(payload -> Event.from(key, (SpecificRecord) payload, timestamp.toInstant()));
+    }
+}


### PR DESCRIPTION
Allow using `KafkaProperties` for overriding default configuration of various event store implementations.