### PR TITLE
Transitively require tech.kage.event in modules

### DIFF
--- a/tech.kage.event.kafka.reactor/src/main/java/module-info.java
+++ b/tech.kage.event.kafka.reactor/src/main/java/module-info.java
@@ -30,7 +30,7 @@
  * @author Dariusz Szpakowski
  */
 module tech.kage.event.kafka.reactor {
-    requires tech.kage.event;
+    requires transitive tech.kage.event;
 
     requires spring.boot.autoconfigure;
 

--- a/tech.kage.event.kafka.streams/src/main/java/module-info.java
+++ b/tech.kage.event.kafka.streams/src/main/java/module-info.java
@@ -30,7 +30,7 @@
  * @author Dariusz Szpakowski
  */
 module tech.kage.event.kafka.streams {
-    requires tech.kage.event;
+    requires transitive tech.kage.event;
 
     requires spring.boot.autoconfigure;
 

--- a/tech.kage.event.postgres/src/main/java/module-info.java
+++ b/tech.kage.event.postgres/src/main/java/module-info.java
@@ -29,7 +29,7 @@
  * @author Dariusz Szpakowski
  */
 module tech.kage.event.postgres {
-    requires tech.kage.event;
+    requires transitive tech.kage.event;
 
     requires spring.beans;
     requires spring.boot.autoconfigure;


### PR DESCRIPTION
Add `requires transitive tech.kage.event` to implementation modules.