### PR TITLE
Ensure single partition for replicator progress topic

### DIFF
--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
@@ -134,7 +134,7 @@ class EventReplicator {
         }
 
         // create progress Kafka topic
-        kafkaAdmin.createOrModifyTopics(TopicBuilder.name(PROGRESS_TOPIC).compact().build());
+        kafkaAdmin.createOrModifyTopics(TopicBuilder.name(PROGRESS_TOPIC).partitions(1).compact().build());
 
         log.info("Reading last replicated event id");
 


### PR DESCRIPTION
Event Replicator stores replication progress in a dedicated Kafka topic and assumes that this topic consists of one partition. This PR configures the replication progress topic to have only 1 partition.