### PR TITLE
Expose event metadata

### DIFF
--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerTest.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.kafka.reactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import reactor.kafka.receiver.ReceiverRecord;
+import tech.kage.event.Event;
+
+/**
+ * Unit tests of
+ * {@link ReactorKafkaEventStore#transform(reactor.kafka.receiver.ReceiverRecord)}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+class ReactorKafkaEventTransformerTest {
+    @ParameterizedTest
+    @MethodSource("testMessages")
+    void transformsMessageIntoEvent(ReceiverRecord<UUID, SpecificRecord> receiverRecord, Event<?> expectedEvent) {
+        // When
+        var transformedEvent = ReactorKafkaEventStore.transform(receiverRecord);
+
+        // Then
+        assertThat(transformedEvent.key())
+                .describedAs("transformed event key")
+                .isEqualTo(expectedEvent.key());
+
+        assertThat(transformedEvent.payload())
+                .describedAs("transformed event payload")
+                .isEqualTo(expectedEvent.payload());
+
+        assertThat(transformedEvent.timestamp())
+                .describedAs("transformed event timestamp")
+                .isEqualTo(expectedEvent.timestamp());
+
+        assertThat(transformedEvent.metadata())
+                .describedAs("transformed event metadata")
+                .containsAllEntriesOf(expectedEvent.metadata());
+    }
+
+    static Stream<Arguments> testMessages() {
+        return Stream.of(
+                arguments(
+                        named(
+                                "message without headers",
+                                message(
+                                        UUID.fromString("bb15137d-8f16-4a19-a023-6845b9d1bead"),
+                                        TestPayload.newBuilder().setText("test payload 1").build(),
+                                        1734149827923l,
+                                        1,
+                                        5,
+                                        null)),
+                        named(
+                                "event without headers",
+                                Event.from(
+                                        UUID.fromString("bb15137d-8f16-4a19-a023-6845b9d1bead"),
+                                        TestPayload.newBuilder().setText("test payload 1").build(),
+                                        Instant.ofEpochMilli(1734149827923l),
+                                        Map.of("partition", 1, "offset", 5l)))),
+                arguments(
+                        named(
+                                "message with headers",
+                                message(
+                                        UUID.fromString("23debd32-09cd-4a20-a403-c18793ecd2d2"),
+                                        TestPayload.newBuilder().setText("test payload 2").build(),
+                                        1734174935363l,
+                                        2,
+                                        8,
+                                        "15".getBytes())),
+                        named(
+                                "event with headers",
+                                Event.from(
+                                        UUID.fromString("23debd32-09cd-4a20-a403-c18793ecd2d2"),
+                                        TestPayload.newBuilder().setText("test payload 2").build(),
+                                        Instant.ofEpochMilli(1734174935363l),
+                                        Map.of("partition", 2, "offset", 8l, "header.id", "15".getBytes())))));
+    }
+
+    private static ReceiverRecord<UUID, SpecificRecord> message(
+            UUID key,
+            SpecificRecord payload,
+            long timestamp,
+            int partition,
+            long offset,
+            byte[] id) {
+        return new ReceiverRecord<>(
+                new ConsumerRecord<>(
+                        "test_events",
+                        partition,
+                        offset,
+                        timestamp,
+                        TimestampType.CREATE_TIME,
+                        -1,
+                        -1,
+                        key,
+                        payload,
+                        id != null ? new RecordHeaders(List.of(new RecordHeader("id", id))) : new RecordHeaders(),
+                        Optional.empty()),
+                null);
+    }
+}

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventTransformerTest.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventTransformerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2024, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.kafka.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import tech.kage.event.Event;
+import tech.kage.event.kafka.streams.KafkaStreamsEventStore.EventTransformer;
+
+/**
+ * Unit tests of {@link KafkaStreamsEventStore.EventTransformer}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+class KafkaStreamsEventTransformerTest {
+    EventTransformer eventTransformer = new EventTransformer();
+
+    @ParameterizedTest
+    @MethodSource("testMessages")
+    void transformsMessagePayloadIntoEvent(
+            FixedKeyRecord<UUID, SpecificRecord> message,
+            FixedKeyProcessorContext<UUID, Event<SpecificRecord>> context,
+            Event<?> expectedEvent) {
+        // Given
+        eventTransformer.init(context);
+
+        // When
+        eventTransformer.process(message);
+
+        // Then
+        var messageValueCaptor = ArgumentCaptor.forClass(Event.class);
+
+        verify(message).withValue(messageValueCaptor.capture());
+
+        Event<?> transformedEvent = messageValueCaptor.getValue();
+
+        assertThat(transformedEvent.key())
+                .describedAs("transformed event key")
+                .isEqualTo(expectedEvent.key());
+
+        assertThat(transformedEvent.payload())
+                .describedAs("transformed event payload")
+                .isEqualTo(expectedEvent.payload());
+
+        assertThat(transformedEvent.timestamp())
+                .describedAs("transformed event timestamp")
+                .isEqualTo(expectedEvent.timestamp());
+
+        assertThat(transformedEvent.metadata())
+                .describedAs("transformed event metadata")
+                .containsAllEntriesOf(expectedEvent.metadata());
+    }
+
+    static Stream<Arguments> testMessages() {
+        return Stream.of(
+                arguments(
+                        named(
+                                "message without headers",
+                                message(
+                                        UUID.fromString("bb15137d-8f16-4a19-a023-6845b9d1bead"),
+                                        TestPayload.newBuilder().setText("test payload 1").build(),
+                                        1734149827923l,
+                                        null)),
+                        named("[partition=1, offset=5]", context(1, 5)),
+                        named(
+                                "event without headers",
+                                Event.from(
+                                        UUID.fromString("bb15137d-8f16-4a19-a023-6845b9d1bead"),
+                                        TestPayload.newBuilder().setText("test payload 1").build(),
+                                        Instant.ofEpochMilli(1734149827923l),
+                                        Map.of("partition", 1, "offset", 5l)))),
+                arguments(
+                        named(
+                                "message with headers",
+                                message(
+                                        UUID.fromString("23debd32-09cd-4a20-a403-c18793ecd2d2"),
+                                        TestPayload.newBuilder().setText("test payload 2").build(),
+                                        1734174935363l,
+                                        "15".getBytes())),
+                        named("[partition=2, offset=8]", context(2, 8)),
+                        named(
+                                "event with headers",
+                                Event.from(
+                                        UUID.fromString("23debd32-09cd-4a20-a403-c18793ecd2d2"),
+                                        TestPayload.newBuilder().setText("test payload 2").build(),
+                                        Instant.ofEpochMilli(1734174935363l),
+                                        Map.of("partition", 2, "offset", 8l, "header.id", "15".getBytes())))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FixedKeyRecord<UUID, SpecificRecord> message(
+            UUID key,
+            SpecificRecord payload,
+            long timestamp,
+            byte[] id) {
+        var message = Mockito.mock(FixedKeyRecord.class);
+
+        given(message.key()).willReturn(key);
+        given(message.value()).willReturn(payload);
+        given(message.timestamp()).willReturn(timestamp);
+        given(message.headers())
+                .willReturn(id != null ? new RecordHeaders(List.of(new RecordHeader("id", id))) : new RecordHeaders());
+
+        return message;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FixedKeyProcessorContext<UUID, Event<SpecificRecord>> context(int partition, long offset) {
+        var recordMetadata = Mockito.mock(RecordMetadata.class);
+
+        given(recordMetadata.partition()).willReturn(partition);
+        given(recordMetadata.offset()).willReturn(offset);
+
+        var context = Mockito.mock(FixedKeyProcessorContext.class);
+
+        given(context.recordMetadata()).willReturn(Optional.of(recordMetadata));
+
+        return context;
+    }
+}

--- a/tech.kage.event/src/main/java/tech/kage/event/Event.java
+++ b/tech.kage.event/src/main/java/tech/kage/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Dariusz Szpakowski
+ * Copyright (c) 2023-2024, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@ package tech.kage.event;
 import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -40,28 +41,32 @@ import org.apache.avro.specific.SpecificRecord;
  * @param key       the {@code Event}'s key
  * @param payload   the {@code Event}'s payload
  * @param timestamp the {@code Event}'s timestamp
+ * @param metadata  the {@code Event}'s metadata
  *
  * @author Dariusz Szpakowski
  */
-public record Event<T extends SpecificRecord>(UUID key, T payload, Instant timestamp) {
+public record Event<T extends SpecificRecord>(UUID key, T payload, Instant timestamp, Map<String, Object> metadata) {
     /**
      * Creates an {@link Event} with a given key, payload and timestamp.
      *
      * @param key       the {@code Event}'s key
      * @param payload   the {@code Event}'s payload
      * @param timestamp the {@code Event}'s timestamp
+     * @param metadata  the {@code Event}'s metadata
      *
-     * @throws NullPointerException if the specified key, payload or timestamp is
-     *                              null
+     * @throws NullPointerException if the specified key, payload, timestamp or
+     *                              metadata is null
      */
-    public Event(UUID key, T payload, Instant timestamp) {
+    public Event(UUID key, T payload, Instant timestamp, Map<String, Object> metadata) {
         Objects.requireNonNull(key, "key must not be null");
         Objects.requireNonNull(payload, "payload must not be null");
         Objects.requireNonNull(timestamp, "timestamp must not be null");
+        Objects.requireNonNull(metadata, "metadata must not be null");
 
         this.key = key;
         this.payload = payload;
         this.timestamp = timestamp.truncatedTo(MILLIS);
+        this.metadata = metadata;
     }
 
     /**
@@ -70,8 +75,9 @@ public record Event<T extends SpecificRecord>(UUID key, T payload, Instant times
      * @param <T>     the {@code Event}'s payload type
      * @param payload the {@code Event}'s payload
      *
-     * @return an {@link Event} with the specified payload, a random key and
-     *         timestamp set to current time truncated to milliseconds
+     * @return an {@link Event} with the specified payload, a random key, timestamp
+     *         set to current time truncated to milliseconds and an empty metadata
+     *         map
      * 
      * @throws NullPointerException if the specified payload is null
      */
@@ -86,8 +92,8 @@ public record Event<T extends SpecificRecord>(UUID key, T payload, Instant times
      * @param key     the {@code Event}'s key
      * @param payload the {@code Event}'s payload
      *
-     * @return an {@link Event} with the specified key and payload and timestamp set
-     *         to current time truncated to milliseconds
+     * @return an {@link Event} with the specified key, payload, timestamp set to
+     *         current time truncated to milliseconds and an empty metadata map
      * 
      * @throws NullPointerException if the specified key or payload is null
      */
@@ -103,13 +109,36 @@ public record Event<T extends SpecificRecord>(UUID key, T payload, Instant times
      * @param payload   the {@code Event}'s payload
      * @param timestamp the {@code Event}'s timestamp
      *
-     * @return an {@link Event} with the specified key, payload and timestamp
-     *         truncated to milliseconds
+     * @return an {@link Event} with the specified key, payload, timestamp truncated
+     *         to milliseconds and an empty metadata map
      * 
      * @throws NullPointerException if the specified key, payload or timestamp is
      *                              null
      */
     public static <T extends SpecificRecord> Event<T> from(UUID key, T payload, Instant timestamp) {
-        return new Event<>(key, payload, timestamp);
+        return new Event<>(key, payload, timestamp, Map.of());
+    }
+
+    /**
+     * Creates an {@link Event} with a given key, payload, timestamp and metadata.
+     *
+     * @param <T>       the {@code Event}'s payload type
+     * @param key       the {@code Event}'s key
+     * @param payload   the {@code Event}'s payload
+     * @param timestamp the {@code Event}'s timestamp
+     * @param metadata  the {@code Event}'s metadata
+     *
+     * @return an {@link Event} with the specified key, payload, timestamp truncated
+     *         to milliseconds and metadata map
+     * 
+     * @throws NullPointerException if the specified key, payload, timestamp or
+     *                              metadata is null
+     */
+    public static <T extends SpecificRecord> Event<T> from(
+            UUID key,
+            T payload,
+            Instant timestamp,
+            Map<String, Object> metadata) {
+        return new Event<>(key, payload, timestamp, metadata);
     }
 }


### PR DESCRIPTION
Add metadata property to the Event model. This allows exposing implementation specific metadata to the event store consumers. Expose information on message partition, offset and headers in case of Kafka based implementations.