### PR TITLE
Bump avro to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <kafka.streams.avro.serde.version>7.4.0</kafka.streams.avro.serde.version>
 
         <!-- Apache Avro -->
-        <avro.version>1.11.4</avro.version>
+        <avro.version>1.12.0</avro.version>
 
         <!-- JaCoCo -->
         <jacoco.version>0.8.11</jacoco.version>


### PR DESCRIPTION
Bumps org.apache.avro:avro from 1.11.4 to 1.12.0.