### PR TITLE
Bump kafka-avro-serializer to 7.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <properties>
         <!-- Kafka Avro Serializer -->
-        <kafka.avro.serializer.version>7.4.0</kafka.avro.serializer.version>
+        <kafka.avro.serializer.version>7.8.0</kafka.avro.serializer.version>
 
         <!-- Kafka Streams Avro SerDe -->
         <kafka.streams.avro.serde.version>7.4.0</kafka.streams.avro.serde.version>


### PR DESCRIPTION
Bumps io.confluent:kafka-avro-serializer from 7.4.0 to 7.8.0.