### PR TITLE
Bump kafka-streams-avro-serde to 7.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <kafka.avro.serializer.version>7.8.0</kafka.avro.serializer.version>
 
         <!-- Kafka Streams Avro SerDe -->
-        <kafka.streams.avro.serde.version>7.4.0</kafka.streams.avro.serde.version>
+        <kafka.streams.avro.serde.version>7.8.0</kafka.streams.avro.serde.version>
 
         <!-- Apache Avro -->
         <avro.version>1.12.0</avro.version>


### PR DESCRIPTION
Bumps io.confluent:kafka-streams-avro-serde from 7.4.0 to 7.8.0.