### PR TITLE
Bump jacoco-maven-plugin to 0.8.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <avro.version>1.12.0</avro.version>
 
         <!-- JaCoCo -->
-        <jacoco.version>0.8.11</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
 
         <!-- Maven GPG Plugin -->
         <gpg.plugin.version>3.0.1</gpg.plugin.version>


### PR DESCRIPTION
Bumps org.jacoco:jacoco-maven-plugin from 0.8.11 to 0.8.12.