### PR TITLE
Refactor Event Replicator to use the crypto module

### DIFF
--- a/tech.kage.event.crypto/src/main/java/module-info.java
+++ b/tech.kage.event.crypto/src/main/java/module-info.java
@@ -37,7 +37,8 @@ module tech.kage.event.crypto {
 
     requires transitive com.google.crypto.tink;
 
-    exports tech.kage.event.crypto to tech.kage.event.postgres, spring.beans, spring.context;
+    exports tech.kage.event.crypto
+            to tech.kage.event.postgres, tech.kage.event.replicator, spring.beans, spring.context;
 
     opens tech.kage.event.crypto to spring.core;
 }

--- a/tech.kage.event.replicator/pom.xml
+++ b/tech.kage.event.replicator/pom.xml
@@ -48,6 +48,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>tech.kage.event</groupId>
+            <artifactId>tech.kage.event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.kage.event</groupId>
+            <artifactId>tech.kage.event.crypto</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jdbc</artifactId>
         </dependency>
@@ -60,11 +70,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
         </dependency>
 
         <dependency>

--- a/tech.kage.event.replicator/src/main/java/module-info.java
+++ b/tech.kage.event.replicator/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Dariusz Szpakowski
+ * Copyright (c) 2023-2025, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,6 +29,9 @@
  * @author Dariusz Szpakowski
  */
 module tech.kage.event.replicator {
+    requires tech.kage.event;
+    requires tech.kage.event.crypto;
+
     requires spring.boot;
     requires spring.boot.autoconfigure;
 
@@ -46,7 +49,6 @@ module tech.kage.event.replicator {
     requires transitive spring.kafka;
     requires spring.messaging;
     requires kafka.clients;
-    requires org.apache.avro;
 
     requires micrometer.core;
 


### PR DESCRIPTION
Use common code from the crypto module to reduce duplication in the Event Replicator.