### PR TITLE
Allow encrypting output events in KafkaStreamsEventStore

### DIFF
--- a/tech.kage.event.crypto/src/main/java/tech/kage/event/crypto/EventEncryptor.java
+++ b/tech.kage.event.crypto/src/main/java/tech/kage/event/crypto/EventEncryptor.java
@@ -43,7 +43,6 @@ import org.springframework.stereotype.Component;
 import com.google.crypto.tink.Aead;
 import com.google.crypto.tink.aead.AeadConfig;
 
-import reactor.core.publisher.Mono;
 import tech.kage.event.Event;
 
 /**
@@ -80,21 +79,21 @@ public class EventEncryptor {
      * 
      * @return encrypted {@code Event}'s payload
      * 
-     * @throws NullPointerException if the specified payload, key, timestamp,
-     *                              metadata or encryptionKey is null
+     * @throws NullPointerException     if the specified payload, key, timestamp,
+     *                                  metadata or encryptionKey is null
+     * @throws GeneralSecurityException if encryption fails
      */
-    public Mono<byte[]> encrypt(byte[] payload, Object key, Instant timestamp, Map<String, Object> metadata,
-            URI encryptionKey) {
+    public byte[] encrypt(byte[] payload, Object key, Instant timestamp, Map<String, Object> metadata,
+            URI encryptionKey) throws GeneralSecurityException {
         Objects.requireNonNull(payload, "payload must not be null");
         Objects.requireNonNull(key, "key must not be null");
         Objects.requireNonNull(timestamp, "timestamp must not be null");
         Objects.requireNonNull(metadata, "metadata must not be null");
         Objects.requireNonNull(encryptionKey, "encryptionKey must not be null");
 
-        return Mono.fromCallable(
-                () -> aeadProvider
-                        .getObject(encryptionKey)
-                        .encrypt(payload, prepareAssociatedData(key, timestamp, metadata)));
+        return aeadProvider
+                .getObject(encryptionKey)
+                .encrypt(payload, prepareAssociatedData(key, timestamp, metadata));
     }
 
     /**

--- a/tech.kage.event.crypto/src/test/java/tech/kage/event/crypto/EventEncryptorIT.java
+++ b/tech.kage.event.crypto/src/test/java/tech/kage/event/crypto/EventEncryptorIT.java
@@ -101,9 +101,7 @@ class EventEncryptorIT {
         var associatedData = eventEncryptor.prepareAssociatedData(key, timestamp, serializedMetadata);
 
         // When
-        var encryptedPayload = eventEncryptor
-                .encrypt(payload, key, timestamp, metadata, encryptionKey)
-                .block();
+        var encryptedPayload = eventEncryptor.encrypt(payload, key, timestamp, metadata, encryptionKey);
 
         // Then
         var decryptedPayload = aead.decrypt(encryptedPayload, associatedData);
@@ -126,9 +124,7 @@ class EventEncryptorIT {
 
         metadataWithEncryptionKey.put(ENCRYPTION_KEY_ID, encryptionKey.toString().getBytes());
 
-        var encryptedPayload = eventEncryptor
-                .encrypt(payload, key, timestamp, metadata, encryptionKey)
-                .block();
+        var encryptedPayload = eventEncryptor.encrypt(payload, key, timestamp, metadata, encryptionKey);
 
         // When
         var decryptedPayload = eventEncryptor.decrypt(encryptedPayload, key, timestamp, metadataWithEncryptionKey);
@@ -154,9 +150,7 @@ class EventEncryptorIT {
 
         metadataWithInvalidKey.put(ENCRYPTION_KEY_ID, invalidEncryptionKey.toString().getBytes());
 
-        var encryptedPayload = eventEncryptor
-                .encrypt(payload, key, timestamp, metadata, encryptionKey)
-                .block();
+        var encryptedPayload = eventEncryptor.encrypt(payload, key, timestamp, metadata, encryptionKey);
 
         // When
         var thrown = assertThrows(Throwable.class,
@@ -184,9 +178,7 @@ class EventEncryptorIT {
 
         metadataWithInvalidKey.put(ENCRYPTION_KEY_ID, encryptionKey.toString().getBytes());
 
-        var encryptedPayload = eventEncryptor
-                .encrypt(payload, key, timestamp, metadata, encryptionKey)
-                .block();
+        var encryptedPayload = eventEncryptor.encrypt(payload, key, timestamp, metadata, encryptionKey);
 
         // When
         var thrown = assertThrows(Throwable.class,
@@ -213,9 +205,7 @@ class EventEncryptorIT {
         metadataWithSourceId.put(ENCRYPTION_KEY_ID, encryptionKey.toString().getBytes());
         metadataWithSourceId.put(SOURCE_ID, "123".getBytes());
 
-        var encryptedPayload = eventEncryptor
-                .encrypt(payload, key, timestamp, metadata, encryptionKey)
-                .block();
+        var encryptedPayload = eventEncryptor.encrypt(payload, key, timestamp, metadata, encryptionKey);
 
         // When
         var decryptedPayload = eventEncryptor.decrypt(encryptedPayload, key, timestamp, metadataWithSourceId);

--- a/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStore.java
+++ b/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStore.java
@@ -89,6 +89,9 @@ import tech.kage.event.crypto.EventEncryptor;
  * and {@code spring.kafka.properties.schema.registry.url} points to a Confluent
  * Schema Registry instance.
  * 
+ * @param <K> the type of stored events' keys
+ * @param <V> the type of stored events' payloads
+ * 
  * @author Dariusz Szpakowski
  */
 @Component

--- a/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformer.java
+++ b/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformer.java
@@ -105,8 +105,8 @@ class ReactorKafkaEventTransformer {
                 .fromCallable(() -> kafkaAvroSerializer.serialize(topic, event.payload()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(serialized -> encryptionKey != null
-                        ? eventEncryptor.encrypt(
-                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey)
+                        ? Mono.fromCallable(() -> eventEncryptor.encrypt(
+                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey))
                         : Mono.just(serialized))
                 .map(serialized -> new ProducerRecord<Object, byte[]>(
                         topic,

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerIT.java
@@ -517,7 +517,8 @@ class ReactorKafkaEventTransformerIT {
         }
     }
 
-    private ReceiverRecord<Object, byte[]> encrypt(ReceiverRecord<Object, byte[]> receiverRecord, URI encryptionKey) {
+    private ReceiverRecord<Object, byte[]> encrypt(ReceiverRecord<Object, byte[]> receiverRecord, URI encryptionKey)
+            throws GeneralSecurityException {
         var metadata = new HashMap<String, Object>();
 
         for (var header : receiverRecord.headers()) {
@@ -534,8 +535,7 @@ class ReactorKafkaEventTransformerIT {
                         receiverRecord.key(),
                         Instant.ofEpochMilli(receiverRecord.timestamp()),
                         metadata,
-                        encryptionKey)
-                .block();
+                        encryptionKey);
 
         return receiverRecord(
                 receiverRecord.key(),

--- a/tech.kage.event.kafka.streams/src/main/java/tech/kage/event/kafka/streams/ProducerRecordEventTransformer.java
+++ b/tech.kage.event.kafka.streams/src/main/java/tech/kage/event/kafka/streams/ProducerRecordEventTransformer.java
@@ -81,8 +81,8 @@ class ProducerRecordEventTransformer {
                 .fromCallable(() -> kafkaAvroSerializer.serialize(topic, event.payload()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(serialized -> encryptionKey != null
-                        ? eventEncryptor.encrypt(
-                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey)
+                        ? Mono.fromCallable(() -> eventEncryptor.encrypt(
+                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey))
                         : Mono.just(serialized))
                 .map(serialized -> new ProducerRecord<>(
                         topic,

--- a/tech.kage.event.postgres/src/main/java/tech/kage/event/postgres/PostgresEventStore.java
+++ b/tech.kage.event.postgres/src/main/java/tech/kage/event/postgres/PostgresEventStore.java
@@ -127,8 +127,8 @@ public class PostgresEventStore<K, V extends SpecificRecord> implements EventSto
                 .fromCallable(() -> kafkaAvroSerializer.serialize(topic, event.payload()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(serialized -> encryptionKey != null
-                        ? eventEncryptor.encrypt(
-                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey)
+                        ? Mono.fromCallable(() -> eventEncryptor.encrypt(
+                                serialized, event.key(), event.timestamp(), event.metadata(), encryptionKey))
                         : Mono.just(serialized))
                 .flatMap(serialized -> databaseClient
                         .sql(event.metadata().isEmpty() && encryptionKey == null


### PR DESCRIPTION
Allows sending events to output topics in Kafka Streams topologies in their authenticated and encrypted form. The encryption scheme used is Authenticated Encryption with Associated Data (AEAD). The event's payload is encrypted and the key, timestamp and metadata are the associated non-encrypted authenticated data.

Uses the Authenticated Encryption with Associated Data (AEAD) primitive provided by the Tink library. Requires a bean implementing the com.google.crypto.tink.Aead interface. Key management is out of scope.