### PR TITLE
Implement locking in Event Replicator

### DIFF
--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/Application.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Dariusz Szpakowski
+ * Copyright (c) 2023-2025, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -25,9 +25,18 @@
 
 package tech.kage.event.replicator;
 
+import javax.sql.DataSource;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import com.zaxxer.hikari.HikariDataSource;
 
 /**
  * Spring Boot application running the process of event replication.
@@ -44,5 +53,29 @@ public class Application {
      */
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    @Primary
+    @ConfigurationProperties(prefix = "spring.datasource")
+    DataSource defaultDataSource(DataSourceProperties dataSourceProperties) {
+        var dataSource = DataSourceBuilder.create().type(HikariDataSource.class).build();
+
+        dataSource.setJdbcUrl(dataSourceProperties.getUrl());
+
+        return dataSource;
+    }
+
+    @Bean(name = "lockManagerDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource")
+    DataSource lockManagerDataSource(DataSourceProperties dataSourceProperties) {
+        var dataSource = DataSourceBuilder.create().type(HikariDataSource.class).build();
+
+        dataSource.setJdbcUrl(dataSourceProperties.getUrl());
+        dataSource.setMaximumPoolSize(1);
+        dataSource.setMinimumIdle(1);
+        dataSource.setPoolName("HikariPool-LockManager");
+
+        return dataSource;
     }
 }

--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/LockManager.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/LockManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.replicator.entity;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component providing locking functionality to ensure that there is only one
+ * instance running.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@Component
+class LockManager {
+    /**
+     * SQL query used for calling pg_try_advisory_lock PostgreSQL function.
+     */
+    private static final String ACQUIRE_LOCK_SQL = "SELECT pg_try_advisory_lock(?)";
+
+    /**
+     * The name of the lock.
+     */
+    private static final String LOCK_NAME = "_event_replicator_lock";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Constructs a new {@link LockManager} instance.
+     *
+     * @param lockManagerDataSource an instance of {@link DataSource}
+     */
+    LockManager(@Qualifier("lockManagerDataSource") DataSource lockManagerDataSource) {
+        jdbcTemplate = new JdbcTemplate(lockManagerDataSource);
+    }
+
+    /**
+     * Tries to acquire the lock.
+     * 
+     * @return {@code true} if lock acquired, {@code false} otherwise
+     */
+    boolean acquireLock() {
+        var lockKey = getLockKey(LOCK_NAME);
+
+        return jdbcTemplate.queryForObject(ACQUIRE_LOCK_SQL, Boolean.class, lockKey);
+    }
+
+    /**
+     * Creates a 64-bit integer from the lock string hash code (higher bits) and
+     * length (lower bits).
+     * 
+     * @param lock lock string to be transformed
+     * 
+     * @return a 64-bit integer generated from the given lock string
+     */
+    private long getLockKey(String lock) {
+        return ((long) lock.hashCode() << 32) | (lock.length() & 0xFFFFFFFFl);
+    }
+}

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/LockManagerIT.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/LockManagerIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.replicator.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * Integration tests for {@link LockManager}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LockManagerIT {
+    @Autowired
+    ObjectProvider<DataSource> dataSourceProvider;
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Configuration
+    @Import(LockManager.class)
+    static class TestConfiguration {
+        @Bean(name = "lockManagerDataSource")
+        @Scope(SCOPE_PROTOTYPE)
+        DataSource lockManagerDataSource() {
+            var dataSource = DataSourceBuilder.create().type(HikariDataSource.class).build();
+
+            dataSource.setJdbcUrl(postgres.getJdbcUrl());
+            dataSource.setUsername(postgres.getUsername());
+            dataSource.setPassword(postgres.getPassword());
+            dataSource.setMaximumPoolSize(1);
+            dataSource.setMinimumIdle(1);
+
+            return dataSource;
+        }
+    }
+
+    @Test
+    @Order(1)
+    void successfullyAcquiresLock() {
+        // Given
+        var dataSource = dataSourceProvider.getObject();
+
+        var lockManager = new LockManager(dataSource);
+
+        // When
+        var locked = lockManager.acquireLock();
+
+        // Then
+        assertThat(locked)
+                .describedAs("lock acquired")
+                .isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void failsToAcquireLockWhenLockAcquiredByAnotherInstance() {
+        // Given
+        var anotherDataSource = dataSourceProvider.getObject();
+        var anotherLockManager = new LockManager(anotherDataSource);
+
+        // When
+        var locked = anotherLockManager.acquireLock();
+
+        // Then
+        assertThat(locked)
+                .describedAs("lock acquired")
+                .isFalse();
+    }
+}

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/LockMonitorTest.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/LockMonitorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.replicator.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests of {@link LockMonitor}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+class LockMonitorTest {
+    @Test
+    void monitorsLockValidity() {
+        // Given
+        var lockManager = mock(LockManager.class);
+        var lockMonitor = new LockMonitor(lockManager);
+
+        given(lockManager.acquireLock()).willReturn(true);
+
+        // When
+        lockMonitor.run();
+
+        // Then
+        verify(lockManager).acquireLock();
+    }
+
+    @Test
+    void shutsDownWhenLockCannotBeAcquired() {
+        // Given
+        var lockManager = mock(LockManager.class);
+        var testableLockMonitor = new TestableLockMonitor(lockManager); // for testing System.exit()
+
+        given(lockManager.acquireLock()).willReturn(false);
+
+        // When
+        testableLockMonitor.run();
+
+        // Then
+        assertThat(testableLockMonitor.getLastExitCode())
+                .describedAs("exit code")
+                .isEqualTo(1);
+    }
+
+    // Testable subclass to intercept System.exit
+    static class TestableLockMonitor extends LockMonitor {
+        private int lastExitCode = -1;
+
+        TestableLockMonitor(LockManager lockManager) {
+            super(lockManager);
+        }
+
+        @Override
+        protected void exit(int code) {
+            this.lastExitCode = code; // Store instead of exiting
+        }
+
+        int getLastExitCode() {
+            return lastExitCode;
+        }
+    }
+}


### PR DESCRIPTION
Until now it was possible to run multiple instances of Event Replicator which could cause event duplicates in Kafka. This PR fixes that by implementing locking. First instance will try to acquire the lock and only if it's successful will it start event replicator workers. If lock acquisition is unsuccessful, the instance is shut down.