### PR TITLE
Implement component auto-configuration

### DIFF
--- a/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStoreAutoConfiguration.java
+++ b/tech.kage.event.kafka.reactor/src/main/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStoreAutoConfiguration.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.kafka.reactor;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.kafka.receiver.MicrometerConsumerListener;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+import tech.kage.event.crypto.EventEncryptor;
+
+/**
+ * Auto-configuration of {@link ReactorKafkaEventStore}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@AutoConfiguration(before = KafkaAutoConfiguration.class)
+@Import({ ReactorKafkaEventStore.class, ReactorKafkaEventTransformer.class, EventEncryptor.class })
+class ReactorKafkaEventStoreAutoConfiguration {
+    private static final String VALUE_SUBJECT_NAME_STRATEGY_CONFIG = "value.subject.name.strategy";
+    private static final String VALUE_SUBJECT_NAME_STRATEGY = "io.confluent.kafka.serializers.subject.RecordNameStrategy";
+
+    private static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
+
+    private static final String KAFKA_AVRO_SERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroSerializer";
+    private static final String KAFKA_AVRO_DESERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
+
+    @Bean
+    KafkaSender<Object, byte[]> kafkaSender(SenderOptions<Object, byte[]> senderOptions) {
+        return KafkaSender.create(senderOptions);
+    }
+
+    @Bean
+    SenderOptions<Object, byte[]> kafkaSenderOptions(KafkaProperties properties) {
+        var props = properties.buildProducerProperties(null);
+
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        return SenderOptions.create(props);
+    }
+
+    @Bean
+    ReceiverOptions<Object, byte[]> kafkaReceiverOptions(
+            KafkaProperties properties,
+            Optional<MeterRegistry> meterRegistry) {
+        var props = properties.buildConsumerProperties(null);
+
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+
+        return ReceiverOptions
+                .<Object, byte[]>create(props)
+                .consumerListener(
+                        meterRegistry.isPresent()
+                                ? new MicrometerConsumerListener(meterRegistry.get())
+                                : null);
+    }
+
+    @Bean
+    Serializer<SpecificRecord> kafkaAvroSerializer(KafkaProperties properties) {
+        var serializerConfig = new HashMap<>(properties.getProperties());
+
+        serializerConfig.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        // Construct a new Kafka Avro Serializer instance via reflection because
+        // kafka-avro-serializer dependency is not compatible with module-info.java
+        // (split package).
+
+        @SuppressWarnings("unchecked")
+        var kafkaAvroSerializer = (Serializer<SpecificRecord>) getInstance(KAFKA_AVRO_SERIALIZER_CLASS);
+
+        kafkaAvroSerializer.configure(serializerConfig, false);
+
+        return kafkaAvroSerializer;
+    }
+
+    @Bean
+    Deserializer<SpecificRecord> kafkaAvroDeserializer(KafkaProperties properties) {
+        var deserializerConfig = new HashMap<>(properties.getProperties());
+
+        deserializerConfig.putIfAbsent(SPECIFIC_AVRO_READER_CONFIG, "true");
+        deserializerConfig.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        // Construct a new Kafka Avro Deserializer instance via reflection because
+        // kafka-avro-serializer dependency is not compatible with module-info.java
+        // (split package).
+
+        @SuppressWarnings("unchecked")
+        var kafkaAvroDeserializer = (Deserializer<SpecificRecord>) getInstance(KAFKA_AVRO_DESERIALIZER_CLASS);
+
+        kafkaAvroDeserializer.configure(deserializerConfig, false);
+
+        return kafkaAvroDeserializer;
+    }
+
+    private Object getInstance(String className) {
+        try {
+            var ctor = Class.forName(className).getConstructor();
+
+            return ctor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate " + className, e);
+        }
+    }
+}

--- a/tech.kage.event.kafka.reactor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tech.kage.event.kafka.reactor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+tech.kage.event.kafka.reactor.ReactorKafkaEventStoreAutoConfiguration

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ByteArrayKeyReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ByteArrayKeyReactorKafkaEventStoreIT.java
@@ -48,6 +48,6 @@ class ByteArrayKeyReactorKafkaEventStoreIT extends ReactorKafkaEventStoreIT<byte
         registry.add("spring.kafka.consumer.key-deserializer", ByteArrayDeserializer.class::getName);
     }
 
-    static class TestConfiguration extends ReactorKafkaEventStoreIT.TestConfiguration {
+    static class TestConfig extends ReactorKafkaEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/EncryptedReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/EncryptedReactorKafkaEventStoreIT.java
@@ -71,7 +71,7 @@ class EncryptedReactorKafkaEventStoreIT extends UUIDKeyReactorKafkaEventStoreIT 
 
     static final Map<URI, KeysetHandle> testKms = new HashMap<>();
 
-    static class TestConfiguration extends ReactorKafkaEventStoreIT.TestConfiguration {
+    static class TestConfig extends ReactorKafkaEventStoreIT.TestConfig {
         @Bean
         @Scope(SCOPE_PROTOTYPE)
         Aead aead(URI encryptionKey) throws GeneralSecurityException {

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/IntegerKeyReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/IntegerKeyReactorKafkaEventStoreIT.java
@@ -48,6 +48,6 @@ class IntegerKeyReactorKafkaEventStoreIT extends ReactorKafkaEventStoreIT<Intege
         registry.add("spring.kafka.consumer.key-deserializer", IntegerDeserializer.class::getName);
     }
 
-    static class TestConfiguration extends ReactorKafkaEventStoreIT.TestConfiguration {
+    static class TestConfig extends ReactorKafkaEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/KafkaReceiverConfigurationTest.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/KafkaReceiverConfigurationTest.java
@@ -46,7 +46,7 @@ import reactor.kafka.receiver.MicrometerConsumerListener;
  */
 class KafkaReceiverConfigurationTest {
     // UUT
-    ReactorKafkaEventStore.Config config = new ReactorKafkaEventStore.Config();
+    ReactorKafkaEventStoreAutoConfiguration config = new ReactorKafkaEventStoreAutoConfiguration();
 
     @Test
     void createsDefaultReceiverConfiguration() {

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/KafkaSenderConfigurationTest.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/KafkaSenderConfigurationTest.java
@@ -40,7 +40,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
  */
 class KafkaSenderConfigurationTest {
     // UUT
-    ReactorKafkaEventStore.Config config = new ReactorKafkaEventStore.Config();
+    ReactorKafkaEventStoreAutoConfiguration config = new ReactorKafkaEventStoreAutoConfiguration();
 
     @Test
     void createsDefaultSenderConfiguration() {

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/MicrometerReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/MicrometerReactorKafkaEventStoreIT.java
@@ -45,10 +45,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaAdmin;
@@ -82,7 +81,9 @@ import tech.kage.event.Event;
  * 
  * @author Dariusz Szpakowski
  */
-@SpringBootTest
+@SpringBootTest(classes = {
+        ReactorKafkaEventStoreAutoConfiguration.class,
+        MicrometerReactorKafkaEventStoreIT.TestConfig.class })
 @ActiveProfiles("test")
 @Testcontainers
 @DirtiesContext
@@ -146,10 +147,9 @@ class MicrometerReactorKafkaEventStoreIT {
                 () -> "http://%s:%s".formatted(schemaRegistry.getHost(), schemaRegistry.getFirstMappedPort()));
     }
 
-    @Configuration
+    @TestConfiguration
     @EnableAutoConfiguration
-    @Import(ReactorKafkaEventStore.class)
-    static class TestConfiguration {
+    static class TestConfig {
         @Bean
         MeterRegistry meterRegistry() {
             return new SimpleMeterRegistry();

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventStoreIT.java
@@ -49,9 +49,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaAdmin;
@@ -137,10 +136,9 @@ abstract class ReactorKafkaEventStoreIT<K> {
                 () -> "http://%s:%s".formatted(schemaRegistry.getHost(), schemaRegistry.getFirstMappedPort()));
     }
 
-    @Configuration
+    @TestConfiguration
     @EnableAutoConfiguration
-    @Import(ReactorKafkaEventStore.class)
-    static class TestConfiguration {
+    static class TestConfig {
     }
 
     @BeforeEach

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/ReactorKafkaEventTransformerIT.java
@@ -70,9 +70,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.convention.TestBean;
@@ -91,7 +90,10 @@ import tech.kage.event.crypto.EventEncryptor;
  * 
  * @author Dariusz Szpakowski
  */
-@SpringBootTest
+@SpringBootTest(classes = {
+        ReactorKafkaEventTransformer.class,
+        EventEncryptor.class,
+        ReactorKafkaEventTransformerIT.TestConfig.class })
 @ActiveProfiles("test")
 class ReactorKafkaEventTransformerIT {
     // UUT
@@ -134,9 +136,8 @@ class ReactorKafkaEventTransformerIT {
 
     static final Map<URI, KeysetHandle> testKms = new HashMap<>();
 
-    @Configuration
-    @Import({ ReactorKafkaEventTransformer.class, EventEncryptor.class })
-    static class TestConfiguration {
+    @TestConfiguration
+    static class TestConfig {
         @Bean
         @Scope(SCOPE_PROTOTYPE)
         Aead aead(URI encryptionKey) throws GeneralSecurityException {

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/StringKeyReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/StringKeyReactorKafkaEventStoreIT.java
@@ -48,6 +48,6 @@ class StringKeyReactorKafkaEventStoreIT extends ReactorKafkaEventStoreIT<String>
         registry.add("spring.kafka.consumer.key-deserializer", StringDeserializer.class::getName);
     }
 
-    static class TestConfiguration extends ReactorKafkaEventStoreIT.TestConfiguration {
+    static class TestConfig extends ReactorKafkaEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/UUIDKeyReactorKafkaEventStoreIT.java
+++ b/tech.kage.event.kafka.reactor/src/test/java/tech/kage/event/kafka/reactor/UUIDKeyReactorKafkaEventStoreIT.java
@@ -50,6 +50,6 @@ class UUIDKeyReactorKafkaEventStoreIT extends ReactorKafkaEventStoreIT<UUID> {
         registry.add("spring.kafka.consumer.key-deserializer", UUIDDeserializer.class::getName);
     }
 
-    static class TestConfiguration extends ReactorKafkaEventStoreIT.TestConfiguration {
+    static class TestConfig extends ReactorKafkaEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.streams/src/main/java/tech/kage/event/kafka/streams/KafkaStreamsEventStoreAutoConfiguration.java
+++ b/tech.kage.event.kafka.streams/src/main/java/tech/kage/event/kafka/streams/KafkaStreamsEventStoreAutoConfiguration.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.kafka.streams;
+
+import java.util.HashMap;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+
+import tech.kage.event.crypto.EventEncryptor;
+
+/**
+ * Auto-configuration of {@link KafkaStreamsEventStore}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@AutoConfiguration(before = KafkaAutoConfiguration.class)
+@EnableKafkaStreams
+@Import({ KafkaStreamsEventStore.class, ProducerRecordEventTransformer.class, KafkaStreamsEventTransformer.class,
+        EventEncryptor.class })
+class KafkaStreamsEventStoreAutoConfiguration {
+    private static final String DEFAULT_VALUE_SERDE_CLASS = "io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde";
+    private static final String VALUE_SUBJECT_NAME_STRATEGY_CONFIG = "value.subject.name.strategy";
+    private static final String VALUE_SUBJECT_NAME_STRATEGY = "io.confluent.kafka.serializers.subject.RecordNameStrategy";
+
+    private static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
+
+    private static final String KAFKA_AVRO_SERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroSerializer";
+    private static final String KAFKA_AVRO_DESERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
+
+    @Bean
+    ProducerFactory<?, ?> kafkaProducerFactory(KafkaProperties properties) {
+        var props = properties.buildProducerProperties(null);
+
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        var factory = new DefaultKafkaProducerFactory<>(props);
+
+        var transactionIdPrefix = properties.getProducer().getTransactionIdPrefix();
+
+        if (transactionIdPrefix != null) {
+            factory.setTransactionIdPrefix(transactionIdPrefix);
+        }
+
+        return factory;
+    }
+
+    @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+    KafkaStreamsConfiguration kStreamsConfig(
+            KafkaProperties properties,
+            @Value(value = "${kafka.streams.application.id}") String applicationId) {
+        var props = new HashMap<String, Object>(properties.getProperties());
+
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, String.join(",", properties.getBootstrapServers()));
+        props.putIfAbsent(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, DEFAULT_VALUE_SERDE_CLASS);
+        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        props.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        return new KafkaStreamsConfiguration(props);
+    }
+
+    @Bean
+    Serializer<SpecificRecord> kafkaAvroSerializer(KafkaProperties properties) {
+        var serializerConfig = new HashMap<>(properties.getProperties());
+
+        serializerConfig.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        // Construct a new Kafka Avro Serializer instance via reflection because
+        // kafka-avro-serializer dependency is not compatible with module-info.java
+        // (split package).
+
+        @SuppressWarnings("unchecked")
+        var kafkaAvroSerializer = (Serializer<SpecificRecord>) getInstance(KAFKA_AVRO_SERIALIZER_CLASS);
+
+        kafkaAvroSerializer.configure(serializerConfig, false);
+
+        return kafkaAvroSerializer;
+    }
+
+    @Bean
+    Deserializer<SpecificRecord> kafkaAvroDeserializer(KafkaProperties properties) {
+        var deserializerConfig = new HashMap<>(properties.getProperties());
+
+        deserializerConfig.putIfAbsent(SPECIFIC_AVRO_READER_CONFIG, "true");
+        deserializerConfig.putIfAbsent(VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        // Construct a new Kafka Avro Deserializer instance via reflection because
+        // kafka-avro-serializer dependency is not compatible with module-info.java
+        // (split package).
+
+        @SuppressWarnings("unchecked")
+        var kafkaAvroDeserializer = (Deserializer<SpecificRecord>) getInstance(KAFKA_AVRO_DESERIALIZER_CLASS);
+
+        kafkaAvroDeserializer.configure(deserializerConfig, false);
+
+        return kafkaAvroDeserializer;
+    }
+
+    private Object getInstance(String className) {
+        try {
+            var ctor = Class.forName(className).getConstructor();
+
+            return ctor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate " + className, e);
+        }
+    }
+}

--- a/tech.kage.event.kafka.streams/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tech.kage.event.kafka.streams/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+tech.kage.event.kafka.streams.KafkaStreamsEventStoreAutoConfiguration

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/ByteArrayKeyKafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/ByteArrayKeyKafkaStreamsEventStoreIT.java
@@ -50,6 +50,6 @@ class ByteArrayKeyKafkaStreamsEventStoreIT extends KafkaStreamsEventStoreIT<byte
         registry.add("spring.kafka.properties.default.key.serde", () -> Serdes.ByteArray().getClass().getName());
     }
 
-    static class TestConfiguration extends KafkaStreamsEventStoreIT.TestConfiguration {
+    static class TestConfig extends KafkaStreamsEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/EncryptedKafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/EncryptedKafkaStreamsEventStoreIT.java
@@ -105,7 +105,7 @@ class EncryptedKafkaStreamsEventStoreIT extends UUIDKeyKafkaStreamsEventStoreIT 
     }
 
     @Import({ KafkaStreamsEventStore.class, TestStreamsSubscriber.class, TestEncryptedStreamsSubscriber.class })
-    static class TestConfiguration extends KafkaStreamsEventStoreIT.TestConfiguration {
+    static class TestConfig extends KafkaStreamsEventStoreIT.TestConfig {
         @Bean
         @Scope(SCOPE_PROTOTYPE)
         Aead aead(URI encryptionKey) throws GeneralSecurityException {

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/IntegerKeyKafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/IntegerKeyKafkaStreamsEventStoreIT.java
@@ -50,6 +50,6 @@ class IntegerKeyKafkaStreamsEventStoreIT extends KafkaStreamsEventStoreIT<Intege
         registry.add("spring.kafka.properties.default.key.serde", () -> Serdes.Integer().getClass().getName());
     }
 
-    static class TestConfiguration extends KafkaStreamsEventStoreIT.TestConfiguration {
+    static class TestConfig extends KafkaStreamsEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaProducerFactoryConfigurationTest.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaProducerFactoryConfigurationTest.java
@@ -45,7 +45,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
  */
 class KafkaProducerFactoryConfigurationTest {
     // UUT
-    KafkaStreamsEventStore.Config config = new KafkaStreamsEventStore.Config();
+    KafkaStreamsEventStoreAutoConfiguration config = new KafkaStreamsEventStoreAutoConfiguration();
 
     @ParameterizedTest
     @MethodSource("testKafkaProperties")

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsConfigurationTest.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsConfigurationTest.java
@@ -40,7 +40,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
  */
 class KafkaStreamsConfigurationTest {
     // UUT
-    KafkaStreamsEventStore.Config config = new KafkaStreamsEventStore.Config();
+    KafkaStreamsEventStoreAutoConfiguration config = new KafkaStreamsEventStoreAutoConfiguration();
 
     @Test
     void createsDefaultKafkaStreamsConfig() {

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventStoreIT.java
@@ -52,8 +52,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.KafkaAdmin;
@@ -143,10 +143,10 @@ abstract class KafkaStreamsEventStoreIT<K> {
         }
     }
 
-    @Configuration
+    @TestConfiguration
     @EnableAutoConfiguration
-    @Import({ KafkaStreamsEventStore.class, TestStreamsSubscriber.class })
-    static class TestConfiguration {
+    @Import(TestStreamsSubscriber.class)
+    static class TestConfig {
         @Bean
         ReceiverOptions<Object, byte[]> kafkaReceiverOptions(KafkaProperties properties) {
             var props = properties.buildConsumerProperties(null);

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventTransformerIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/KafkaStreamsEventTransformerIT.java
@@ -71,9 +71,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.convention.TestBean;
@@ -90,7 +89,10 @@ import tech.kage.event.crypto.EventEncryptor;
  * 
  * @author Dariusz Szpakowski
  */
-@SpringBootTest
+@SpringBootTest(classes = {
+        KafkaStreamsEventTransformer.class,
+        EventEncryptor.class,
+        KafkaStreamsEventTransformerIT.TestConfig.class })
 @ActiveProfiles("test")
 class KafkaStreamsEventTransformerIT {
     // UUT
@@ -133,9 +135,8 @@ class KafkaStreamsEventTransformerIT {
 
     static final Map<URI, KeysetHandle> testKms = new HashMap<>();
 
-    @Configuration
-    @Import({ KafkaStreamsEventTransformer.class, EventEncryptor.class })
-    static class TestConfiguration {
+    @TestConfiguration
+    static class TestConfig {
         @Bean
         @Scope(SCOPE_PROTOTYPE)
         Aead aead(URI encryptionKey) throws GeneralSecurityException {

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/StringKeyKafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/StringKeyKafkaStreamsEventStoreIT.java
@@ -50,6 +50,6 @@ class StringKeyKafkaStreamsEventStoreIT extends KafkaStreamsEventStoreIT<String>
         registry.add("spring.kafka.properties.default.key.serde", () -> Serdes.String().getClass().getName());
     }
 
-    static class TestConfiguration extends KafkaStreamsEventStoreIT.TestConfiguration {
+    static class TestConfig extends KafkaStreamsEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/UUIDKeyKafkaStreamsEventStoreIT.java
+++ b/tech.kage.event.kafka.streams/src/test/java/tech/kage/event/kafka/streams/UUIDKeyKafkaStreamsEventStoreIT.java
@@ -52,6 +52,6 @@ class UUIDKeyKafkaStreamsEventStoreIT extends KafkaStreamsEventStoreIT<UUID> {
         registry.add("spring.kafka.properties.default.key.serde", () -> Serdes.UUID().getClass().getName());
     }
 
-    static class TestConfiguration extends KafkaStreamsEventStoreIT.TestConfiguration {
+    static class TestConfig extends KafkaStreamsEventStoreIT.TestConfig {
     }
 }

--- a/tech.kage.event.postgres/src/main/java/tech/kage/event/postgres/PostgresEventStoreAutoConfiguration.java
+++ b/tech.kage.event.postgres/src/main/java/tech/kage/event/postgres/PostgresEventStoreAutoConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.common.serialization.Serializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import tech.kage.event.crypto.EventEncryptor;
+
+/**
+ * Auto-configuration of {@link PostgresEventStore}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@AutoConfiguration
+@Import({ PostgresEventStore.class, EventEncryptor.class })
+class PostgresEventStoreAutoConfiguration {
+    private static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
+    private static final String SCHEMA_REGISTRY_URL_NOT_SET_ERROR = "schema.registry.url must be set";
+
+    private static final String VALUE_SUBJECT_NAME_STRATEGY_CONFIG = "value.subject.name.strategy";
+    private static final String VALUE_SUBJECT_NAME_STRATEGY = "io.confluent.kafka.serializers.subject.RecordNameStrategy";
+
+    private static final String KAFKA_AVRO_SERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroSerializer";
+
+    /**
+     * Creates an Avro enabled Kafka {@link Serializer}.
+     * 
+     * @param schemaRegistryUrl address pointing to a Confluent Schema Registry
+     *                          instance (required if {@link KafkaProperties} bean
+     *                          is not available)
+     * @param kafkaProperties   {@link KafkaProperties} bean used for configuring
+     *                          the serializer (optional)
+     * 
+     * @return an instance of {@link Serializer}
+     */
+    @Bean
+    Serializer<SpecificRecord> kafkaAvroSerializer(
+            @Value("${" + SCHEMA_REGISTRY_URL_CONFIG + ":#{null}}") String schemaRegistryUrl,
+            Optional<KafkaProperties> kafkaProperties) {
+        var serializerConfig = kafkaProperties.isPresent()
+                ? kafkaProperties.get().getProperties()
+                : Map.of(
+                        SCHEMA_REGISTRY_URL_CONFIG,
+                        Objects.requireNonNull(schemaRegistryUrl, SCHEMA_REGISTRY_URL_NOT_SET_ERROR),
+                        VALUE_SUBJECT_NAME_STRATEGY_CONFIG, VALUE_SUBJECT_NAME_STRATEGY);
+
+        var kafkaAvroSerializer = getSerializerInstance();
+
+        kafkaAvroSerializer.configure(serializerConfig, false);
+
+        return kafkaAvroSerializer;
+    }
+
+    /**
+     * Constructs a new Kafka Avro Serializer instance. Uses reflection because
+     * {@code kafka-avro-serializer} dependency is not compatible with
+     * {@code module-info.java} (split package).
+     * 
+     * @return new Kafka Avro Serializer instance
+     */
+    @SuppressWarnings("unchecked")
+    private Serializer<SpecificRecord> getSerializerInstance() {
+        try {
+            var ctor = Class.forName(KAFKA_AVRO_SERIALIZER_CLASS).getConstructor();
+
+            return (Serializer<SpecificRecord>) ctor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate serializer " + KAFKA_AVRO_SERIALIZER_CLASS, e);
+        }
+    }
+}

--- a/tech.kage.event.postgres/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tech.kage.event.postgres/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+tech.kage.event.postgres.PostgresEventStoreAutoConfiguration

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/ByteArrayKeyPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/ByteArrayKeyPostgresEventStoreIT.java
@@ -49,7 +49,7 @@ class ByteArrayKeyPostgresEventStoreIT extends PostgresEventStoreIT<byte[]> {
         return "bytea";
     }
 
-    static class TestConfiguration extends PostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends PostgresEventStoreIT.TestConfig {
     }
 
     static Stream<Arguments> testEvents() {

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/EncryptedPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/EncryptedPostgresEventStoreIT.java
@@ -65,7 +65,7 @@ class EncryptedPostgresEventStoreIT extends UUIDKeyPostgresEventStoreIT {
 
     static final Map<URI, KeysetHandle> testKms = new HashMap<>();
 
-    static class TestConfiguration extends UUIDKeyPostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends UUIDKeyPostgresEventStoreIT.TestConfig {
         @Bean
         @Scope(SCOPE_PROTOTYPE)
         Aead aead(URI encryptionKey) throws GeneralSecurityException {

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/IntegerKeyPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/IntegerKeyPostgresEventStoreIT.java
@@ -44,11 +44,12 @@ import tech.kage.event.Event;
  * @author Dariusz Szpakowski
  */
 class IntegerKeyPostgresEventStoreIT extends PostgresEventStoreIT<Integer> {
+    @Override
     protected String getKeyType() {
         return "integer";
     }
 
-    static class TestConfiguration extends PostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends PostgresEventStoreIT.TestConfig {
     }
 
     static Stream<Arguments> testEvents() {

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/PostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/PostgresEventStoreIT.java
@@ -59,10 +59,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.test.context.ActiveProfiles;
@@ -135,10 +134,9 @@ abstract class PostgresEventStoreIT<K> {
                 () -> "http://%s:%s".formatted(schemaRegistry.getHost(), schemaRegistry.getFirstMappedPort()));
     }
 
-    @Configuration
+    @TestConfiguration
     @EnableAutoConfiguration
-    @Import(PostgresEventStore.class)
-    static class TestConfiguration {
+    static class TestConfig {
         private static final String DESERIALIZER_CLASS = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
 
         @Bean

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/StringKeyPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/StringKeyPostgresEventStoreIT.java
@@ -49,7 +49,7 @@ class StringKeyPostgresEventStoreIT extends PostgresEventStoreIT<String> {
         return "text";
     }
 
-    static class TestConfiguration extends PostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends PostgresEventStoreIT.TestConfig {
     }
 
     static Stream<Arguments> testEvents() {

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/UUIDKeyPostgresEventStoreIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/UUIDKeyPostgresEventStoreIT.java
@@ -49,7 +49,7 @@ class UUIDKeyPostgresEventStoreIT extends PostgresEventStoreIT<UUID> {
         return "uuid";
     }
 
-    static class TestConfiguration extends PostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends PostgresEventStoreIT.TestConfig {
     }
 
     static Stream<Arguments> testEvents() {

--- a/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/UUIDKeyPostgresEventStoreWithKafkaPropertiesIT.java
+++ b/tech.kage.event.postgres/src/test/java/tech/kage/event/postgres/UUIDKeyPostgresEventStoreWithKafkaPropertiesIT.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Bean;
  * @author Dariusz Szpakowski
  */
 class UUIDKeyPostgresEventStoreWithKafkaPropertiesIT extends UUIDKeyPostgresEventStoreIT {
-    static class TestConfiguration extends PostgresEventStoreIT.TestConfiguration {
+    static class TestConfig extends PostgresEventStoreIT.TestConfig {
         @Bean
         KafkaProperties kafkaProperties(@Value("${schema.registry.url}") String schemaRegistryUrl) {
             var kafkaProperties = mock(KafkaProperties.class);


### PR DESCRIPTION
This PR adds auto-configuration for event store implementations, removing the need to manually `@Import` them.