### PR TITLE
Bump spring-boot to 3.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.6</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Bumps org.springframework.boot:spring-boot-starter-parent from 3.4.1 to 3.4.6.