### PR TITLE
Implement WAL LSN-based event replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ CREATE TABLE IF NOT EXISTS events.test_events (
     key uuid NOT NULL,
     data bytea NOT NULL,
     metadata bytea,
-    timestamp timestamp with time zone NOT NULL
+    timestamp timestamp with time zone NOT NULL,
+    lsn pg_lsn
 );
+
+CREATE INDEX IF NOT EXISTS test_events_lsn_idx ON events.test_events (lsn);
 ```
 
 **Maven configuration:**
@@ -86,7 +89,7 @@ eventStore.save("sample_encrypted_topic", event, encryptionKey);
 
 **Replicate events to Kafka**
 
-See [Event Replicator](tech.kage.event.replicator).
+Replication requires the [LSN Updater](tech.kage.event.postgres.lsnupdater) and the [Event Replicator](tech.kage.event.replicator) to be running. The LSN Updater populates the `lsn` column via PostgreSQL logical replication, and the Event Replicator copies events to Kafka topics ordered by their WAL position.
 
 **Process events**
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <module>tech.kage.event.kafka.reactor</module>
         <module>tech.kage.event.kafka.streams</module>
         <module>tech.kage.event.postgres</module>
+        <module>tech.kage.event.postgres.lsnupdater</module>
         <module>tech.kage.event.replicator</module>
     </modules>
 

--- a/tech.kage.event.postgres.lsnupdater/LICENSE
+++ b/tech.kage.event.postgres.lsnupdater/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2026, Dariusz Szpakowski
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tech.kage.event.postgres.lsnupdater/README.md
+++ b/tech.kage.event.postgres.lsnupdater/README.md
@@ -1,0 +1,122 @@
+# PostgreSQL Event LSN Updater
+
+LSN updater for PostgreSQL event tables using logical replication.
+
+Connects to a PostgreSQL logical replication slot and listens for INSERT operations on tables ending with the `_events` suffix. For each inserted row, updates its `lsn` column with the WAL location (Log Sequence Number) of the corresponding change.
+
+## Getting started
+
+Given a database schema:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS events;
+
+CREATE TABLE IF NOT EXISTS events.test_events (
+    id bigserial PRIMARY KEY,
+    key uuid NOT NULL,
+    data bytea NOT NULL,
+    metadata bytea,
+    timestamp timestamp with time zone NOT NULL,
+    lsn pg_lsn
+);
+```
+
+ensure `wal_level` is set to `logical` in `postgresql.conf` if not already configured:
+
+```
+wal_level = logical
+```
+
+then create a publication and a logical replication slot:
+
+```sql
+CREATE PUBLICATION event_lsn_publication
+FOR TABLES IN SCHEMA events
+WITH (publish = 'insert');
+
+SELECT pg_create_logical_replication_slot('event_lsn_updater', 'pgoutput');
+```
+
+run:
+
+```
+java -jar tech.kage.event.postgres.lsnupdater-$VERSION.jar --spring.datasource.url=jdbc:postgresql://localhost:5432/testdb --spring.datasource.username=postgres --spring.datasource.password=postgres
+```
+
+## Assumptions
+
+- Event tables follow a fixed schema: `id bigserial PRIMARY KEY` as the first column, followed by `key`, `data`, `metadata`, `timestamp`, and `lsn pg_lsn`. Table names must end with the `_events` suffix.
+- Events are immutable — rows are never updated or deleted after insertion.
+- The LSN update is eventually consistent. There is a short window after an INSERT during which `lsn` is NULL. Downstream consumers (e.g. event-replicator) query with `WHERE lsn IS NOT NULL` to naturally wait for the LSN to be set.
+- The process is designed to fail fast on any unrecoverable error and must be run under a process supervisor (e.g. Kubernetes, systemd) that restarts it automatically. On restart, the replication slot is resumed from its last confirmed position and any pending messages are replayed safely.
+
+## Configuration
+
+The list of supported configuration properties is given below.
+
+**Database configuration**
+
+- `spring.datasource.url` or `DATABASE_URL` environment variable - sets database URL (e.g. "jdbc:postgresql://localhost:5432/testdb").
+- `spring.datasource.username` or `DATABASE_USERNAME` environment variable - sets database username.
+- `spring.datasource.password` or `DATABASE_PASSWORD` environment variable - sets database password.
+
+**LSN updater configuration**
+
+- `event.lsn.updater.enabled` - enables or disables the LSN updater (set to `true` by default).
+- `event.lsn.updater.slot.name` - logical replication slot name (set to "event_lsn_updater" by default).
+- `event.lsn.updater.publication.name` - publication name (set to "event_lsn_publication" by default).
+
+## Observability
+
+A health endpoint is available at `http://<host>:<MANAGEMENT_PORT>/actuator/health` (default port: 9191) for use as a Kubernetes liveness probe.
+
+Sample SQL queries useful for monitoring the LSN updater.
+
+**Replication slot status**
+
+```sql
+SELECT slot_name, active, restart_lsn, confirmed_flush_lsn,
+       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+FROM pg_replication_slots
+WHERE slot_name = 'event_lsn_updater';
+```
+
+**Replication lag (bytes behind current WAL position)**
+
+```sql
+SELECT slot_name,
+       pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS lag_bytes,
+       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)) AS lag_pretty
+FROM pg_replication_slots
+WHERE slot_name = 'event_lsn_updater';
+```
+
+**Rows pending LSN update in a given event table**
+
+```sql
+SELECT count(*) AS pending_lsn_count
+FROM events.test_events
+WHERE lsn IS NULL;
+```
+
+**Latest LSN values written**
+
+```sql
+SELECT id, lsn, timestamp
+FROM events.test_events
+WHERE lsn IS NOT NULL
+ORDER BY id DESC
+LIMIT 10;
+```
+
+**Publication tables**
+
+```sql
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'event_lsn_publication';
+```
+
+## License
+
+This project is released under the [BSD 2-Clause License](LICENSE).

--- a/tech.kage.event.postgres.lsnupdater/pom.xml
+++ b/tech.kage.event.postgres.lsnupdater/pom.xml
@@ -13,10 +13,10 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>tech.kage.event.replicator</artifactId>
+    <artifactId>tech.kage.event.postgres.lsnupdater</artifactId>
 
-    <name>tech.kage.event.replicator</name>
-    <description>Replicator of events from PostgreSQL tables to Kafka topics</description>
+    <name>tech.kage.event.postgres.lsnupdater</name>
+    <description>LSN updater for PostgreSQL event tables using logical replication</description>
     <url>https://github.com/kagetech/event-store</url>
 
     <licenses>
@@ -48,38 +48,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>tech.kage.event</groupId>
-            <artifactId>tech.kage.event</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>tech.kage.event</groupId>
-            <artifactId>tech.kage.event.crypto</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
         <dependency>
@@ -117,8 +92,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/module-info.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/module-info.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * LSN updater for PostgreSQL event tables using logical replication.
+ * 
+ * @author Dariusz Szpakowski
+ */
+module tech.kage.event.postgres.lsnupdater {
+    requires spring.boot;
+    requires spring.boot.autoconfigure;
+
+    requires spring.beans;
+    requires spring.context;
+    requires transitive spring.core;
+
+    requires org.slf4j;
+
+    // Entity
+    requires spring.jdbc;
+    requires spring.tx;
+    requires java.sql;
+    requires org.postgresql.jdbc;
+
+    requires jakarta.annotation;
+
+    exports tech.kage.event.postgres.lsnupdater to spring.beans, spring.context;
+    exports tech.kage.event.postgres.lsnupdater.entity to spring.beans, spring.context;
+
+    opens tech.kage.event.postgres.lsnupdater to spring.core;
+    opens tech.kage.event.postgres.lsnupdater.entity to spring.core;
+}

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/Application.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/Application.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Boot application running the LSN updater service.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@SpringBootApplication
+public class Application {
+    /**
+     * The application's entry point.
+     * 
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdater.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdater.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater.entity;
+
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.postgresql.PGConnection;
+import org.postgresql.PGProperty;
+import org.postgresql.replication.PGReplicationStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+
+/**
+ * Component that uses PostgreSQL logical replication to update LSN columns in
+ * events tables.
+ * Connects to an existing replication slot and processes INSERT operations to
+ * set the LSN value for each inserted row.
+ * 
+ * <h2>Correctness invariants</h2>
+ * <ul>
+ * <li>Messages are processed sequentially in a single thread — the UPDATE for
+ * row N always commits before the UPDATE for row N+1 begins.</li>
+ * <li>Each UPDATE runs with auto-commit via {@link JdbcTemplate}. The
+ * replication slot is only advanced after the UPDATE has been committed.
+ * This guarantees that a crash at any point results in at-least-once
+ * delivery, never data loss.</li>
+ * <li>Replay after crash is idempotent — re-processing an INSERT writes
+ * the same LSN value to the same row.</li>
+ * <li>Any processing error terminates the process (fail-fast). An external
+ * supervisor is expected to restart it.</li>
+ * </ul>
+ * 
+ * @author Dariusz Szpakowski
+ */
+@Component
+@ConditionalOnProperty(name = "event.lsn.updater.enabled", matchIfMissing = true)
+class LsnUpdater {
+    private static final Logger log = LoggerFactory.getLogger(LsnUpdater.class);
+
+    /**
+     * SQL query template for updating LSN column.
+     */
+    private static final String UPDATE_LSN_SQL = "UPDATE %s.%s SET lsn = ?::pg_lsn WHERE id = ?";
+
+    /**
+     * The suffix that all event tables need to have.
+     */
+    private static final String TOPIC_SUFFIX = "_events";
+
+    private final PgOutputMessageParser parser;
+    private final JdbcTemplate jdbcTemplate;
+    private final DataSourceProperties dataSourceProperties;
+
+    /**
+     * Configuration property defining the replication slot name.
+     */
+    @Value("${event.lsn.updater.slot.name:event_lsn_updater}")
+    private String slotName;
+
+    /**
+     * Configuration property defining the publication name.
+     */
+    @Value("${event.lsn.updater.publication.name:event_lsn_publication}")
+    private String publicationName;
+
+    private Thread replicationThread;
+    private Connection replicationConnection;
+    private PGReplicationStream replicationStream;
+
+    /**
+     * Constructs a new {@link LsnUpdater} instance.
+     *
+     * @param parser               an instance of {@link PgOutputMessageParser}
+     * @param jdbcTemplate         an instance of {@link JdbcTemplate}
+     * @param dataSourceProperties an instance of {@link DataSourceProperties}
+     */
+    LsnUpdater(PgOutputMessageParser parser, JdbcTemplate jdbcTemplate, DataSourceProperties dataSourceProperties) {
+        this.parser = parser;
+        this.jdbcTemplate = jdbcTemplate;
+        this.dataSourceProperties = dataSourceProperties;
+    }
+
+    /**
+     * Starts the LSN updater after component initialization.
+     */
+    @PostConstruct
+    void init() throws SQLException {
+        log.info("Starting LSN updater with slot: {}, publication: {}", slotName, publicationName);
+
+        connectToReplicationSlot();
+
+        replicationThread = new Thread(this::runReplication, "lsn-updater");
+
+        replicationThread.setDaemon(false);
+        replicationThread.setUncaughtExceptionHandler((thread, throwable) -> {
+            log.error("LSN updater thread crashed, terminating process", throwable);
+
+            exit(1);
+        });
+
+        replicationThread.start();
+    }
+
+    /**
+     * Stops the LSN updater before component destruction.
+     */
+    @PreDestroy
+    void destroy() throws Exception {
+        log.info("Stopping LSN updater");
+
+        replicationThread.interrupt();
+        replicationThread.join(5000);
+
+        try {
+            replicationStream.close();
+        } finally {
+            replicationConnection.close();
+        }
+    }
+
+    /**
+     * Main replication loop running in a background thread.
+     */
+    private void runReplication() {
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                var message = replicationStream.readPending();
+
+                if (message == null) {
+                    TimeUnit.MILLISECONDS.sleep(10L);
+                    continue;
+                }
+
+                processMessage(message);
+
+                // Send feedback to server
+                var lastRecv = replicationStream.getLastReceiveLSN();
+
+                replicationStream.setAppliedLSN(lastRecv);
+                replicationStream.setFlushedLSN(lastRecv);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            throw new IllegalStateException("LSN updater replication loop failed", e);
+        }
+    }
+
+    /**
+     * Connects to the replication slot.
+     */
+    private void connectToReplicationSlot() throws SQLException {
+        var props = new Properties();
+
+        PGProperty.USER.set(props, dataSourceProperties.getUsername());
+        PGProperty.PASSWORD.set(props, dataSourceProperties.getPassword());
+        PGProperty.ASSUME_MIN_SERVER_VERSION.set(props, "10.0");
+        PGProperty.REPLICATION.set(props, "database");
+        PGProperty.PREFER_QUERY_MODE.set(props, "simple");
+        PGProperty.CONNECT_TIMEOUT.set(props, "10");
+        PGProperty.SOCKET_TIMEOUT.set(props, "30");
+
+        replicationConnection = DriverManager.getConnection(dataSourceProperties.getUrl(), props);
+
+        var pgConnection = replicationConnection.unwrap(PGConnection.class);
+
+        replicationStream = pgConnection
+                .getReplicationAPI()
+                .replicationStream()
+                .logical()
+                .withSlotName(slotName)
+                .withSlotOption("proto_version", "1")
+                .withSlotOption("publication_names", publicationName)
+                .start();
+
+        log.info("Connected to replication slot: {}", slotName);
+    }
+
+    /**
+     * Processes a replication message.
+     *
+     * @param message replication payload buffer read from the stream
+     */
+    private void processMessage(ByteBuffer message) {
+        var messageInfo = parser.parse(message);
+
+        if (messageInfo != null && messageInfo.type() == MessageType.INSERT) {
+            processInsert(messageInfo);
+        }
+    }
+
+    /**
+     * Processes an INSERT message and updates the LSN column.
+     *
+     * @param messageInfo parsed replication message details
+     */
+    private void processInsert(MessageInfo messageInfo) {
+        var relationInfo = messageInfo.relationInfo();
+        var insertInfo = messageInfo.insertInfo();
+
+        // Only process tables ending with _events suffix
+        if (!relationInfo.table().endsWith(TOPIC_SUFFIX)) {
+            return;
+        }
+
+        // Get the id value from the INSERT
+        var id = insertInfo.idValue();
+
+        if (id == null) {
+            throw new IllegalStateException(
+                    "INSERT for " + relationInfo.schema() + "." + relationInfo.table() + " is missing id value");
+        }
+
+        // Get LSN from the replication stream
+        var lsn = replicationStream.getLastReceiveLSN();
+
+        // Update the LSN column
+        updateLsn(relationInfo.schema(), relationInfo.table(), id, lsn.asString());
+    }
+
+    /**
+     * Updates the LSN column for a specific row.
+     *
+     * @param schema schema containing the target table
+     * @param table  target table name
+     * @param id     row identifier to update
+     * @param lsn    WAL location to persist in the row
+     */
+    private void updateLsn(String schema, String table, Long id, String lsn) {
+        var sql = UPDATE_LSN_SQL.formatted(schema, table);
+
+        var rowsUpdated = jdbcTemplate.update(sql, lsn, id);
+
+        if (rowsUpdated != 1) {
+            throw new IllegalStateException("Expected exactly one row updated for "
+                    + schema + "." + table + " id=" + id + ", but got " + rowsUpdated);
+        }
+
+        log.debug("Updated LSN for {}.{} id={} to {}", schema, table, id, lsn);
+    }
+
+    // Added for testability
+    protected void exit(int code) {
+        System.exit(code);
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParser.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParser.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCESSING OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater.entity;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Parser for PostgreSQL pgoutput binary protocol messages.
+ * Handles RELATION and INSERT messages, skips other message types.
+ * 
+ * <p>
+ * The parser assumes a fixed event table schema where {@code id} is always
+ * the first column and is of type {@code bigserial} (bigint). Column metadata
+ * from RELATION messages is not validated — only the relation ID, schema, and
+ * table name are extracted.
+ * 
+ * <p>
+ * The message format is documented in the <a href=
+ * "https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html">PostgreSQL
+ * Logical Replication Message Formats</a> documentation.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@Component
+class PgOutputMessageParser {
+    /**
+     * Message type byte for RELATION (table metadata).
+     */
+    private static final byte MESSAGE_TYPE_RELATION = 'R';
+
+    /**
+     * Message type byte for INSERT.
+     */
+    private static final byte MESSAGE_TYPE_INSERT = 'I';
+
+    /**
+     * Mapping of relation IDs to schema/table names.
+     */
+    private final Map<Integer, RelationInfo> relations = new ConcurrentHashMap<>();
+
+    /**
+     * Parses a pgoutput message from the given ByteBuffer.
+     * 
+     * @param buffer the ByteBuffer containing the message
+     * 
+     * @return parsed message info, or null if message type is not handled
+     */
+    MessageInfo parse(ByteBuffer buffer) {
+        if (buffer.remaining() < 1) {
+            return null;
+        }
+
+        var messageType = buffer.get();
+
+        return switch (messageType) {
+            case MESSAGE_TYPE_RELATION -> parseRelation(buffer);
+            case MESSAGE_TYPE_INSERT -> parseInsert(buffer);
+            default -> null;
+        };
+    }
+
+    /**
+     * Parses a RELATION message.
+     * Format: relationId (4 bytes, big-endian), namespace (null-terminated string),
+     * relation name (null-terminated string), followed by column metadata
+     * (ignored).
+     * 
+     * @param buffer byte buffer containing the RELATION message payload
+     * 
+     * @return parsed relation message information
+     */
+    private MessageInfo parseRelation(ByteBuffer buffer) {
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        var relationId = buffer.getInt();
+        var namespace = readNullTerminatedString(buffer);
+        var relationName = readNullTerminatedString(buffer);
+
+        // Column metadata is ignored (we assume id is always the first column)
+
+        var relationInfo = new RelationInfo(relationId, namespace, relationName);
+
+        relations.put(relationId, relationInfo);
+
+        return new MessageInfo(MessageType.RELATION, relationInfo, null);
+    }
+
+    /**
+     * Parses an INSERT message.
+     * Format: relationId (4 bytes, big-endian), new tuple data
+     * 
+     * @param buffer byte buffer containing the INSERT message payload
+     * 
+     * @return parsed insert message information
+     */
+    private MessageInfo parseInsert(ByteBuffer buffer) {
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        var relationId = buffer.getInt();
+
+        var relationInfo = relations.get(relationId);
+
+        if (relationInfo == null) {
+            throw new IllegalStateException(
+                    "Received INSERT for relation OID " + relationId + " before corresponding RELATION message");
+        }
+
+        var idValue = parseIdValue(buffer);
+
+        return new MessageInfo(MessageType.INSERT, relationInfo, new InsertInfo(relationId, idValue));
+    }
+
+    /**
+     * Parses the id value from tuple data in the buffer.
+     * Assumes id is always the first column and NOT NULL bigserial (bigint).
+     * Format: 'N' (1 byte) for new tuple, column count (2 bytes, big-endian),
+     * for each column: format indicator (1 byte: 't' = text), value length
+     * (4 bytes, big-endian), value bytes (text format).
+     * 
+     * @param buffer byte buffer containing tuple data
+     * 
+     * @return the id value as Long
+     */
+    private Long parseIdValue(ByteBuffer buffer) {
+        var tupleType = buffer.get();
+
+        if (tupleType != 'N') { // 'N' for new tuple
+            throw new IllegalStateException("Unexpected INSERT tuple type: " + (char) tupleType);
+        }
+
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        buffer.getShort(); // skip column count
+
+        var firstColumnFormat = buffer.get();
+
+        if (firstColumnFormat != 't') { // 't' for text
+            throw new IllegalStateException("Unexpected INSERT first column format: " + (char) firstColumnFormat);
+        }
+
+        var valueLength = buffer.getInt();
+        var valueBytes = new byte[valueLength];
+
+        buffer.get(valueBytes);
+
+        return Long.parseLong(new String(valueBytes, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Reads a null-terminated string from the buffer.
+     * 
+     * @param buffer byte buffer positioned at the start of a null-terminated string
+     * 
+     * @return decoded UTF-8 string without the null terminator
+     */
+    private String readNullTerminatedString(ByteBuffer buffer) {
+        var start = buffer.position();
+        var length = 0;
+
+        while (buffer.get() != 0) {
+            length++;
+        }
+
+        buffer.position(start);
+
+        var bytes = new byte[length];
+
+        buffer.get(bytes);
+        buffer.get(); // skip null terminator
+
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Message type enumeration.
+     */
+    enum MessageType {
+        RELATION,
+        INSERT
+    }
+
+    /**
+     * Container for parsed message information.
+     * 
+     * @param type         parsed message type
+     * @param relationInfo relation metadata extracted from the message
+     * @param insertInfo   insert metadata extracted from the message
+     */
+    static record MessageInfo(MessageType type, RelationInfo relationInfo, InsertInfo insertInfo) {
+    }
+
+    /**
+     * Information about a database relation (table).
+     * 
+     * @param relationId internal relation identifier from pgoutput
+     * @param schema     relation schema name
+     * @param table      relation table name
+     */
+    static record RelationInfo(int relationId, String schema, String table) {
+    }
+
+    /**
+     * Information about an INSERT operation.
+     * 
+     * @param relationId internal relation identifier from pgoutput
+     * @param idValue    parsed id column value
+     */
+    static record InsertInfo(int relationId, Long idValue) {
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/package-info.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Components performing the LSN update process via logical replication.
+ * 
+ * @author Dariusz Szpakowski
+ */
+package tech.kage.event.postgres.lsnupdater.entity;

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/package-info.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * LSN updater for PostgreSQL event tables using logical replication.
+ * 
+ * @author Dariusz Szpakowski
+ */
+package tech.kage.event.postgres.lsnupdater;

--- a/tech.kage.event.postgres.lsnupdater/src/main/resources/application.properties
+++ b/tech.kage.event.postgres.lsnupdater/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Management configuration
+server.port=${MANAGEMENT_PORT:9191}
+management.endpoints.web.exposure.include=health
+
+# Database configuration
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+
+# Logging configuration
+# logging.level.org.springframework.jdbc.core=trace

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterErrorHandlingIT.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterErrorHandlingIT.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationInfo;
+
+/**
+ * Integration tests for {@link LsnUpdater} error handling.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+class LsnUpdaterErrorHandlingIT {
+    // UUT
+    @Autowired
+    TestableLsnUpdater lsnUpdater;
+
+    @MockitoBean
+    PgOutputMessageParser parser;
+
+    @MockitoBean
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    DataSource dataSource;
+
+    @SuppressWarnings("resource")
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withCommand("postgres", "-c", "wal_level=logical")
+            .withInitScript("test-data/lsn-updater/init.sql");
+
+    @DynamicPropertySource
+    static void dataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class TestConfiguration {
+        @Bean
+        TestableLsnUpdater lsnUpdater(
+                PgOutputMessageParser parser,
+                JdbcTemplate jdbcTemplate,
+                DataSourceProperties dataSourceProperties) {
+            return new TestableLsnUpdater(parser, jdbcTemplate, dataSourceProperties);
+        }
+    }
+
+    @Test
+    void terminatesProcessWhenParserThrows() {
+        // Given
+        given(parser.parse(any())).willThrow(new IllegalStateException("parse error"));
+
+        // When
+        insertTestEvent("11111111-1111-1111-1111-111111111111");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(1));
+    }
+
+    @Test
+    void terminatesProcessWhenInsertHasNullId() {
+        // Given
+        given(parser.parse(any())).willAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte type = buf.get(buf.position());
+
+            if (type == 'I') {
+                return new MessageInfo(
+                        MessageType.INSERT,
+                        new RelationInfo(1, "events", "test_events"),
+                        new InsertInfo(1, null));
+            }
+
+            return null;
+        });
+
+        // When
+        insertTestEvent("22222222-2222-2222-2222-222222222222");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(1));
+    }
+
+    @Test
+    void terminatesProcessWhenUpdateLsnAffectsUnexpectedNumberOfRows() {
+        // Given
+        given(jdbcTemplate.update(anyString(), any(), any())).willReturn(0);
+
+        given(parser.parse(any())).willAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte type = buf.get(buf.position());
+
+            if (type == 'I') {
+                return new MessageInfo(
+                        MessageType.INSERT,
+                        new RelationInfo(1, "events", "test_events"),
+                        new InsertInfo(1, 123L));
+            }
+
+            return null;
+        });
+
+        // When
+        insertTestEvent("44444444-4444-4444-4444-444444444444");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(1));
+    }
+
+    @Test
+    void continuesProcessingWhenNonEventsTableInsertReceived() {
+        // Given
+        given(parser.parse(any())).willAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte type = buf.get(buf.position());
+
+            if (type == 'I') {
+                return new MessageInfo(
+                        MessageType.INSERT,
+                        new RelationInfo(1, "events", "some_other_table"),
+                        new InsertInfo(1, 123L));
+            }
+
+            return null;
+        });
+
+        // When
+        insertTestEvent("33333333-3333-3333-3333-333333333333");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> verify(parser, atLeast(1)).parse(any()));
+
+        await()
+                .during(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(-1));
+    }
+
+    private void insertTestEvent(String key) {
+        new JdbcTemplate(dataSource).execute(
+                "INSERT INTO events.test_events (key, data, metadata, timestamp) VALUES ('%s', decode('AA', 'hex'), null, now())"
+                        .formatted(key));
+    }
+
+    static class TestableLsnUpdater extends LsnUpdater {
+        private volatile int lastExitCode = -1;
+
+        TestableLsnUpdater(
+                PgOutputMessageParser parser,
+                JdbcTemplate jdbcTemplate,
+                DataSourceProperties dataSourceProperties) {
+            super(parser, jdbcTemplate, dataSourceProperties);
+        }
+
+        @Override
+        protected void exit(int code) {
+            this.lastExitCode = code;
+        }
+
+        int getLastExitCode() {
+            return lastExitCode;
+        }
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterIT.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration tests for {@link LsnUpdater}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "event.lsn.updater.enabled=true")
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LsnUpdaterIT {
+    // UUT
+    @Autowired
+    LsnUpdater lsnUpdater;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @SuppressWarnings("resource")
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withCommand("postgres", "-c", "wal_level=logical")
+            .withInitScript("test-data/lsn-updater/init.sql");
+
+    @DynamicPropertySource
+    static void dataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @Import({ LsnUpdater.class, PgOutputMessageParser.class })
+    static class TestConfiguration {
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.execute("TRUNCATE TABLE events.test_events");
+    }
+
+    @Test
+    @Order(1)
+    void updatesLsnForInsertedRow() {
+        // Given
+        // LsnUpdater is running via Spring context
+
+        // When
+        var id = jdbcTemplate.queryForObject("""
+                INSERT INTO events.test_events (key, data, metadata, timestamp)
+                VALUES ('11111111-1111-1111-1111-111111111111', decode('AA', 'hex'), null, now())
+                RETURNING id
+                """, Long.class);
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    var lsn = jdbcTemplate.queryForObject(
+                            "SELECT lsn::text FROM events.test_events WHERE id = ?",
+                            String.class,
+                            id);
+
+                    assertThat(lsn)
+                            .describedAs("lsn for id %d", id)
+                            .isNotNull();
+                });
+    }
+
+    @Test
+    @Order(2)
+    void updatesLsnForMultipleInsertedRows() {
+        // Given
+        // LsnUpdater is running via Spring context
+
+        // When
+        var ids = jdbcTemplate.queryForList("""
+                INSERT INTO events.test_events (key, data, metadata, timestamp)
+                VALUES ('22222222-2222-2222-2222-222222222222', decode('BB', 'hex'), null, now()),
+                       ('33333333-3333-3333-3333-333333333333', decode('CC', 'hex'), null, now()),
+                       ('44444444-4444-4444-4444-444444444444', decode('DD', 'hex'), null, now())
+                RETURNING id
+                """, Long.class);
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    var lsnValues = jdbcTemplate.queryForList(
+                            "SELECT lsn::text FROM events.test_events WHERE id IN (?, ?, ?)",
+                            String.class,
+                            ids.get(0), ids.get(1), ids.get(2));
+
+                    assertThat(lsnValues)
+                            .hasSize(3)
+                            .doesNotContainNull();
+                });
+    }
+
+    @Test
+    @Order(3)
+    void stopsProcessingAfterDestroy() throws Exception {
+        // Given
+        // LsnUpdater is running via Spring context
+
+        // When
+        lsnUpdater.destroy();
+
+        // Then
+        var id = jdbcTemplate.queryForObject("""
+                INSERT INTO events.test_events (key, data, metadata, timestamp)
+                VALUES ('55555555-5555-5555-5555-555555555555', decode('EE', 'hex'), null, now())
+                RETURNING id
+                """, Long.class);
+
+        await()
+                .during(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    var lsn = jdbcTemplate.queryForObject(
+                            "SELECT lsn::text FROM events.test_events WHERE id = ?",
+                            String.class,
+                            id);
+
+                    assertThat(lsn)
+                            .describedAs("lsn for id %d after destroy", id)
+                            .isNull();
+                });
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParserTest.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParserTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026, Dariusz Szpakowski
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.kage.event.postgres.lsnupdater.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationInfo;
+
+/**
+ * Tests of {@link PgOutputMessageParser}.
+ * 
+ * @author Dariusz Szpakowski
+ */
+class PgOutputMessageParserTest {
+    // UUT
+    PgOutputMessageParser parser = new PgOutputMessageParser();
+
+    @Test
+    void parsesRelationMessages() throws IOException {
+        // Given
+        var buffer = buildRelationMessage(12345, "events", "user_events", "id", "key", "data");
+
+        var expected = new MessageInfo(
+                MessageType.RELATION,
+                new RelationInfo(12345, "events", "user_events"),
+                null);
+
+        // When
+        var result = parser.parse(buffer);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testInsertMessagesWithKnownRelation")
+    void parsesInsertMessagesWithKnownRelation(ByteBuffer relationBuffer, ByteBuffer insertBuffer, MessageInfo expected)
+            throws IOException {
+        // Given
+        parser.parse(relationBuffer); // Parse RELATION message first to register relation metadata in the parser
+
+        // When
+        var result = parser.parse(insertBuffer);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> testInsertMessagesWithKnownRelation() throws IOException {
+        return Stream.of(
+                arguments(
+                        named("insert with id at first position",
+                                buildRelationMessage(100, "events", "test_events", "id", "key", "data")),
+                        buildInsertMessage(100, "42"),
+                        new MessageInfo(
+                                MessageType.INSERT,
+                                new RelationInfo(100, "events", "test_events"),
+                                new InsertInfo(100, 42L))),
+                arguments(
+                        named("insert with large id value",
+                                buildRelationMessage(300, "events", "big_events", "id")),
+                        buildInsertMessage(300, "9223372036854775807"),
+                        new MessageInfo(
+                                MessageType.INSERT,
+                                new RelationInfo(300, "events", "big_events"),
+                                new InsertInfo(300, Long.MAX_VALUE))));
+    }
+
+    @Test
+    void handlesMultipleRelationsAndInserts() throws IOException {
+        // Given
+        var relation1 = buildRelationMessage(1, "events", "events_a", "id", "data");
+        var relation2 = buildRelationMessage(2, "events", "events_b", "id", "key");
+
+        // Parse RELATION messages first to register relation metadata in the parser
+        parser.parse(relation1);
+        parser.parse(relation2);
+
+        var inserts = List.of(buildInsertMessage(1, "100"), buildInsertMessage(2, "200"));
+
+        var expected = List.of(
+                new MessageInfo(
+                        MessageType.INSERT,
+                        new RelationInfo(1, "events", "events_a"),
+                        new InsertInfo(1, 100L)),
+                new MessageInfo(
+                        MessageType.INSERT,
+                        new RelationInfo(2, "events", "events_b"),
+                        new InsertInfo(2, 200L)));
+
+        // When
+        var results = inserts.stream().map(parser::parse).toList();
+
+        // Then
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    void failsWhenInsertIsReceivedBeforeRelationMessage() throws IOException {
+        // Given
+        var insertBuffer = buildInsertMessage(999, "42");
+
+        // When
+        var thrown = assertThrows(Throwable.class, () -> parser.parse(insertBuffer));
+
+        // Then
+        assertThat(thrown)
+                .describedAs("thrown exception")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("relation OID 999");
+    }
+
+    @Test
+    void failsWhenInsertTupleTypeIsUnexpected() throws IOException {
+        // Given
+        parser.parse(buildRelationMessage(100, "events", "test_events", "id", "key", "data"));
+
+        var insertBuffer = buildInsertMessage(100, "42");
+
+        insertBuffer.put(5, (byte) 'O'); // replace tuple type 'N' with unsupported value
+
+        // When
+        var thrown = assertThrows(Throwable.class, () -> parser.parse(insertBuffer));
+
+        // Then
+        assertThat(thrown)
+                .describedAs("thrown exception")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("tuple type");
+    }
+
+    @Test
+    void failsWhenInsertFirstColumnFormatIsUnexpected() throws IOException {
+        // Given
+        parser.parse(buildRelationMessage(100, "events", "test_events", "id", "key", "data"));
+
+        var insertBuffer = buildInsertMessage(100, "42");
+
+        insertBuffer.put(8, (byte) 'n'); // replace column format 't' with unsupported value
+
+        // When
+        var thrown = assertThrows(Throwable.class, () -> parser.parse(insertBuffer));
+
+        // Then
+        assertThat(thrown)
+                .describedAs("thrown exception")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("first column format");
+    }
+
+    @ParameterizedTest
+    @MethodSource("testUnknownMessages")
+    void handlesUnknownMessages(ByteBuffer buffer) {
+        // When
+        var result = parser.parse(buffer);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    static Stream<Arguments> testUnknownMessages() {
+        return Stream.of(
+                arguments(named("empty buffer", ByteBuffer.allocate(0))),
+                arguments(named("unknown message type 'X'", ByteBuffer.allocate(1).put((byte) 'X').flip())),
+                arguments(named("BEGIN message", ByteBuffer.allocate(1).put((byte) 'B').flip())),
+                arguments(named("COMMIT message", ByteBuffer.allocate(1).put((byte) 'C').flip())));
+    }
+
+    /**
+     * Builds a RELATION message buffer.
+     * Format: 'R' (1 byte), relationId (4 bytes), namespace (null-terminated),
+     * relation name (null-terminated), replica identity (1 byte),
+     * column count (2 bytes), for each column: flags (1 byte),
+     * name (null-terminated), type OID (4 bytes), atttypmod (4 bytes)
+     */
+    private static ByteBuffer buildRelationMessage(int relationId, String namespace, String relationName,
+            String... columnNames) throws IOException {
+        var out = new ByteArrayOutputStream();
+
+        out.write('R'); // message type
+
+        // relation ID (4 bytes, big-endian)
+        out.write(toBytes(relationId));
+
+        // namespace (null-terminated)
+        out.write(namespace.getBytes(StandardCharsets.UTF_8));
+        out.write(0);
+
+        // relation name (null-terminated)
+        out.write(relationName.getBytes(StandardCharsets.UTF_8));
+        out.write(0);
+
+        // replica identity (1 byte)
+        out.write('d');
+
+        // column count (2 bytes, big-endian)
+        out.write((columnNames.length >> 8) & 0xFF);
+        out.write(columnNames.length & 0xFF);
+
+        // columns
+        for (var columnName : columnNames) {
+            out.write(0); // flags
+            out.write(columnName.getBytes(StandardCharsets.UTF_8));
+            out.write(0); // null terminator
+            out.write(toBytes(20)); // type OID (20 = int8/bigint)
+            out.write(toBytes(-1)); // atttypmod
+        }
+
+        var bytes = out.toByteArray();
+
+        return ByteBuffer.wrap(bytes);
+    }
+
+    /**
+     * Builds an INSERT message buffer with id as the first column.
+     * Format: 'I' (1 byte), relationId (4 bytes), 'N' (1 byte for new tuple),
+     * column count (2 bytes), for id column: 't' (1 byte), value length (4
+     * bytes), value bytes
+     */
+    private static ByteBuffer buildInsertMessage(int relationId, String idValue) throws IOException {
+        var out = new ByteArrayOutputStream();
+
+        out.write('I'); // message type
+
+        // relation ID (4 bytes, big-endian)
+        out.write(toBytes(relationId));
+
+        // 'N' for new tuple
+        out.write('N');
+
+        // column count (2 bytes, big-endian) - just 1 column (id)
+        out.write(0);
+        out.write(1);
+
+        // id column
+        out.write('t'); // text format
+        var idBytes = idValue.getBytes(StandardCharsets.UTF_8);
+        out.write(toBytes(idBytes.length));
+        out.write(idBytes);
+
+        var bytes = out.toByteArray();
+
+        return ByteBuffer.wrap(bytes);
+    }
+
+    /**
+     * Converts an int to 4 bytes in big-endian order.
+     */
+    private static byte[] toBytes(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(value).array();
+    }
+}

--- a/tech.kage.event.postgres.lsnupdater/src/test/resources/test-data/lsn-updater/init.sql
+++ b/tech.kage.event.postgres.lsnupdater/src/test/resources/test-data/lsn-updater/init.sql
@@ -9,4 +9,8 @@ CREATE TABLE IF NOT EXISTS events.test_events (
     lsn pg_lsn
 );
 
-CREATE INDEX IF NOT EXISTS test_events_lsn_idx ON events.test_events (lsn);
+CREATE PUBLICATION event_lsn_publication
+FOR TABLES IN SCHEMA events
+WITH (publish = 'insert');
+
+SELECT pg_create_logical_replication_slot('event_lsn_updater', 'pgoutput');

--- a/tech.kage.event.postgres/src/test/resources/test-data/events/ddl.sql
+++ b/tech.kage.event.postgres/src/test/resources/test-data/events/ddl.sql
@@ -5,7 +5,10 @@ CREATE TABLE IF NOT EXISTS events.test_events (
     key <<key_type>> NOT NULL,
     data bytea NOT NULL,
     metadata bytea,
-    timestamp timestamp with time zone NOT NULL
+    timestamp timestamp with time zone NOT NULL,
+    lsn pg_lsn
 );
+
+CREATE INDEX IF NOT EXISTS test_events_lsn_idx ON events.test_events (lsn);
 
 TRUNCATE TABLE events.test_events;

--- a/tech.kage.event.replicator/README.md
+++ b/tech.kage.event.replicator/README.md
@@ -2,7 +2,9 @@
 
 Replicator of events from PostgreSQL relational tables to Apache Kafka topics with exactly-once semantics (EOS).
 
-Reads topic tables in `event.replicator.event.schema` schema and copies events to Kafka topics with the same name. Stores replication progress in a Kafka topic. Uses Kafka transactions to guarantee EOS.
+Reads topic tables in `event.replicator.event.schema` schema and copies events to Kafka topics with the same name. Orders events by their WAL position (`lsn` column) to preserve true commit order. Stores replication progress in a Kafka topic. Uses Kafka transactions to guarantee EOS.
+
+Requires the [LSN Updater](../tech.kage.event.postgres.lsnupdater) to be running. The LSN Updater populates the `lsn` column via PostgreSQL logical replication. Events without an `lsn` value are not replicated.
 
 ## Getting started
 
@@ -16,8 +18,11 @@ CREATE TABLE IF NOT EXISTS events.test_events (
     key uuid NOT NULL,
     data bytea NOT NULL,
     metadata bytea,
-    timestamp timestamp with time zone NOT NULL
+    timestamp timestamp with time zone NOT NULL,
+    lsn pg_lsn
 );
+
+CREATE INDEX IF NOT EXISTS test_events_lsn_idx ON events.test_events (lsn);
 ```
 
 run:

--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
@@ -27,7 +27,6 @@ package tech.kage.event.replicator.entity;
 
 import static java.util.stream.Collectors.toList;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
@@ -157,18 +156,18 @@ class EventReplicator {
         // create progress Kafka topic
         kafkaAdmin.createOrModifyTopics(TopicBuilder.name(PROGRESS_TOPIC).partitions(1).compact().build());
 
-        log.info("Reading last replicated event ids...");
+        log.info("Reading last replicated event LSNs...");
 
-        // read last replicated event ids (map topic->id)
-        var lastIds = readLastIds(getReplicatedTopics(jdbcTemplate), consumerFactory);
+        // read last replicated event LSNs (map topic->lsn)
+        var lastLsns = readLastLsns(getReplicatedTopics(jdbcTemplate), consumerFactory);
 
         log.info("Scheduling workers...");
 
         // for each replicated topic
-        for (var lastId : lastIds.entrySet()) {
+        for (var lastLsn : lastLsns.entrySet()) {
             // create replicated Kafka topic
             kafkaAdmin.createOrModifyTopics(
-                    TopicBuilder.name(lastId.getKey()).config(TopicConfig.RETENTION_MS_CONFIG, "-1").build());
+                    TopicBuilder.name(lastLsn.getKey()).config(TopicConfig.RETENTION_MS_CONFIG, "-1").build());
 
             // schedule a new worker for the replicated topic
             taskScheduler.scheduleWithFixedDelay(
@@ -178,8 +177,8 @@ class EventReplicator {
                             meterRegistry,
                             environment,
                             eventSchema,
-                            lastId.getKey(),
-                            lastId.getValue()),
+                            lastLsn.getKey(),
+                            lastLsn.getValue()),
                     Duration.ofMillis(pollInterval));
         }
 
@@ -204,21 +203,20 @@ class EventReplicator {
     }
 
     /**
-     * Reads a list of replicated topics by reading a list of tables with
-     * {@code TOPIC_SUFFIX} suffix in the {@code eventSchema} database schema.
+     * Reads the last replicated LSNs for each topic from the progress Kafka topic.
      * 
      * @param replicatedTopics a list of replicated topics
      * @param consumerFactory  an instance of {@link ConsumerFactory}
      * 
-     * @return map of topics with the ids of the last replicated events
+     * @return map of topics with the LSNs of the last replicated events
      */
-    private Map<String, Long> readLastIds(
+    private Map<String, String> readLastLsns(
             List<String> replicatedTopics,
             ConsumerFactory<byte[], byte[]> consumerFactory) {
-        var lastIds = new HashMap<String, Long>();
+        var lastLsns = new HashMap<String, String>();
 
         for (var topic : replicatedTopics) {
-            lastIds.put(topic, 0l);
+            lastLsns.put(topic, "0/0");
         }
 
         var topicPartition = List.of(new TopicPartition(PROGRESS_TOPIC, 0));
@@ -241,7 +239,7 @@ class EventReplicator {
                 var topic = stringFromBytes(consumerRecord.key());
 
                 if (replicatedTopics.contains(topic)) {
-                    lastIds.put(topic, longFromBytes(consumerRecord.value()));
+                    lastLsns.put(topic, stringFromBytes(consumerRecord.value()));
                 }
             }
 
@@ -252,7 +250,7 @@ class EventReplicator {
             }
         }
 
-        return lastIds;
+        return lastLsns;
     }
 
     private byte[] stringToBytes(String str) {
@@ -261,13 +259,5 @@ class EventReplicator {
 
     private String stringFromBytes(byte[] bytes) {
         return new String(bytes, StandardCharsets.UTF_8);
-    }
-
-    private long longFromBytes(byte[] bytes) {
-        return ByteBuffer
-                .allocate(Long.BYTES)
-                .put(bytes)
-                .flip()
-                .getLong();
     }
 }

--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicatorWorker.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicatorWorker.java
@@ -27,8 +27,8 @@ package tech.kage.event.replicator.entity;
 
 import static java.util.Comparator.comparing;
 import static tech.kage.event.EventStore.SOURCE_ID;
+import static tech.kage.event.EventStore.SOURCE_LSN;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.List;
@@ -59,15 +59,15 @@ class EventReplicatorWorker implements Runnable {
     private static final String SELECT_EVENT_SQL = """
                 SELECT *
                 FROM %s.%s
-                WHERE id > %s
-                ORDER BY id
+                WHERE lsn IS NOT NULL AND lsn > '%s'::pg_lsn
+                ORDER BY lsn
                 LIMIT %s
             """;
 
     /**
-     * SQL query used for selecting the id of the last event.
+     * SQL query used for computing the replication lag as WAL byte distance.
      */
-    private static final String SELECT_LAST_EVENT_ID_SQL = "SELECT last_value FROM %s.%s_id_seq";
+    private static final String SELECT_LAG_SQL = "SELECT MAX(lsn) - '%s'::pg_lsn FROM %s.%s WHERE lsn IS NOT NULL";
 
     /**
      * Configuration property defining the maximum number of events replicated in
@@ -83,7 +83,7 @@ class EventReplicatorWorker implements Runnable {
     /**
      * The description of Micrometer event replication lag gauge.
      */
-    private static final String MICROMETER_LAG_GAUGE_DESC = "The difference between the latest event in the source topic and the latest replicated event";
+    private static final String MICROMETER_LAG_GAUGE_DESC = "The WAL byte distance between the latest event in the source topic and the latest replicated event";
 
     /**
      * The name of Micrometer topic tag.
@@ -97,7 +97,7 @@ class EventReplicatorWorker implements Runnable {
     private final String replicatedTopic;
     private final int maxRows;
 
-    private long lastId;
+    private String lastLsn;
 
     /**
      * Constructs a new {@link EventReplicatorWorker} instance.
@@ -108,7 +108,7 @@ class EventReplicatorWorker implements Runnable {
      * @param environment     an instance of {@link Environment}
      * @param eventSchema     the name of the event schema
      * @param replicatedTopic the name of the replicated topic
-     * @param lastId          the id of the last replicated event in the replicated
+     * @param lastLsn         the LSN of the last replicated event in the replicated
      *                        topic
      */
     EventReplicatorWorker(
@@ -118,7 +118,7 @@ class EventReplicatorWorker implements Runnable {
             Environment environment,
             String eventSchema,
             String replicatedTopic,
-            long lastId) {
+            String lastLsn) {
         this.jdbcTemplate = jdbcTemplate;
         this.kafkaTemplate = kafkaTemplate;
 
@@ -126,7 +126,7 @@ class EventReplicatorWorker implements Runnable {
         this.replicatedTopic = replicatedTopic;
         this.maxRows = environment.getProperty(MAX_ROWS_PROPERTY, Integer.class, 100);
 
-        this.lastId = lastId;
+        this.lastLsn = lastLsn;
 
         Gauge
                 .builder(MICROMETER_LAG_GAUGE_NAME, this, worker -> worker.computeLag())
@@ -141,10 +141,10 @@ class EventReplicatorWorker implements Runnable {
     @Override
     public void run() {
         while (true) {
-            var updatedLastId = pollAndSendBatch(eventSchema, replicatedTopic, lastId, maxRows);
+            var updatedLastLsn = pollAndSendBatch(eventSchema, replicatedTopic, lastLsn, maxRows);
 
-            if (updatedLastId != null) {
-                lastId = updatedLastId;
+            if (updatedLastLsn != null) {
+                lastLsn = updatedLastLsn;
             } else {
                 // no more events found so we are done
                 return;
@@ -158,15 +158,15 @@ class EventReplicatorWorker implements Runnable {
      * 
      * @param schema    the name of the event schema
      * @param topic     the name of the replicated topic
-     * @param lastId    the id of the last replicated event in the replicated
+     * @param lastLsn   the LSN of the last replicated event in the replicated
      *                  topic
      * @param batchSize maximum number of events replicated in one batch.
      * 
-     * @return id of the last replicated event or null if no events were found
+     * @return LSN of the last replicated event or null if no events were found
      */
-    private Long pollAndSendBatch(String schema, String topic, long lastId, int batchSize) {
+    private String pollAndSendBatch(String schema, String topic, String lastLsn, int batchSize) {
         // select the events for replication
-        var eventList = jdbcTemplate.queryForList(SELECT_EVENT_SQL.formatted(schema, topic, lastId, batchSize));
+        var eventList = jdbcTemplate.queryForList(SELECT_EVENT_SQL.formatted(schema, topic, lastLsn, batchSize));
 
         if (eventList.isEmpty()) {
             return null;
@@ -174,25 +174,26 @@ class EventReplicatorWorker implements Runnable {
 
         // send events to Kafka and update progress topic in one transaction
         return kafkaTemplate.executeInTransaction(kafka -> {
-            Long newLastId = null;
+            String newLastLsn = null;
 
             for (var event : eventList) {
-                newLastId = (Long) event.get("id");
+                var id = (Long) event.get("id");
+                newLastLsn = event.get("lsn").toString();
 
                 var key = event.get("key");
                 var data = (byte[]) event.get("data");
                 var metadata = (byte[]) event.get("metadata");
                 var timestamp = (Timestamp) event.get("timestamp");
-                var headers = toHeaders(newLastId, metadata);
+                var headers = toHeaders(id, newLastLsn, metadata);
 
                 // send event to Kafka topic
                 kafka.send(new ProducerRecord<>(topic, null, timestamp.getTime(), serializeKey(key), data, headers));
             }
 
             // update progress topic
-            kafka.send(EventReplicator.PROGRESS_TOPIC, stringToBytes(replicatedTopic), longToBytes(newLastId));
+            kafka.send(EventReplicator.PROGRESS_TOPIC, stringToBytes(replicatedTopic), stringToBytes(newLastLsn));
 
-            return newLastId;
+            return newLastLsn;
         });
     }
 
@@ -204,14 +205,16 @@ class EventReplicatorWorker implements Runnable {
         return stringToBytes(key.toString());
     }
 
-    private List<Header> toHeaders(Long id, byte[] metadata) {
+    private List<Header> toHeaders(Long id, String lsn, byte[] metadata) {
         return Stream
                 .concat(
-                        Stream.of(Map.entry(SOURCE_ID, Long.toString(id).getBytes())),
+                        Stream.of(
+                                Map.entry(SOURCE_ID, Long.toString(id).getBytes()),
+                                Map.entry(SOURCE_LSN, lsn.getBytes())),
                         MetadataSerializer.deserialize(metadata).entrySet().stream())
                 .map(e -> new RecordHeader(e.getKey().toString(), (byte[]) e.getValue()))
                 .map(Header.class::cast)
-                .sorted(comparing(Header::key)) // sort again after adding the id header
+                .sorted(comparing(Header::key)) // sort again after adding the id and lsn headers
                 .toList();
     }
 
@@ -219,24 +222,17 @@ class EventReplicatorWorker implements Runnable {
         return str.getBytes(StandardCharsets.UTF_8);
     }
 
-    private byte[] longToBytes(long val) {
-        return ByteBuffer
-                .allocate(Long.BYTES)
-                .putLong(val)
-                .array();
-    }
-
     /**
-     * Computes the event replication lag, i.e. the difference between the latest
+     * Computes the event replication lag as WAL byte distance between the latest
      * event in the source topic and the latest replicated event.
      * 
-     * @return computed replication lag
+     * @return computed replication lag in WAL bytes
      */
     private double computeLag() {
-        var lastSourceId = jdbcTemplate.queryForObject(
-                SELECT_LAST_EVENT_ID_SQL.formatted(eventSchema, replicatedTopic),
+        var lag = jdbcTemplate.queryForObject(
+                SELECT_LAG_SQL.formatted(lastLsn, eventSchema, replicatedTopic),
                 Long.class);
 
-        return lastSourceId - lastId;
+        return lag != null ? lag : 0;
     }
 }

--- a/tech.kage.event.replicator/src/main/resources/application.properties
+++ b/tech.kage.event.replicator/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.task.scheduling.pool.size=20
 
 # Management configuration
-server.port=${MANAGEMENT_PORT:9191}
+server.port=${MANAGEMENT_PORT:9292}
 management.endpoints.web.exposure.include=health,prometheus
 
 # Database configuration

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorIT.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorIT.java
@@ -38,11 +38,10 @@ import static org.mockito.Mockito.verify;
 import static tech.kage.event.replicator.entity.EventReplicator.PROGRESS_TOPIC;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
-import java.util.stream.LongStream;
+import java.util.stream.IntStream;
 
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
@@ -116,7 +115,7 @@ class EventReplicatorIT {
     @MockitoBean
     TaskScheduler taskScheduler;
 
-    Map<String, Long> topicLastIds;
+    Map<String, String> topicLastLsns;
 
     @Container
     @ServiceConnection
@@ -134,14 +133,16 @@ class EventReplicatorIT {
 
     @BeforeEach
     void setUp(@Value("classpath:/test-data/events/ddl.sql") Resource ddl) throws IOException {
-        topicLastIds = LongStream
+        topicLastLsns = IntStream
                 .rangeClosed(1, 10)
                 .boxed()
-                .map(id -> Map.entry("test_" + id + System.currentTimeMillis() + "_events", id))
+                .map(id -> Map.entry(
+                        "test_" + id + System.currentTimeMillis() + "_events",
+                        "0/" + Integer.toHexString(id)))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // create source event tables
-        for (var topic : topicLastIds.keySet()) {
+        for (var topic : topicLastLsns.keySet()) {
             jdbcTemplate.execute(
                     ddl.getContentAsString(StandardCharsets.UTF_8)
                             .replace("<<topic_name>>", topic)
@@ -152,7 +153,7 @@ class EventReplicatorIT {
     @AfterEach
     void tearDown() {
         // drop source event tables
-        for (var topic : topicLastIds.keySet()) {
+        for (var topic : topicLastLsns.keySet()) {
             jdbcTemplate.execute("drop table events." + topic);
         }
     }
@@ -168,7 +169,7 @@ class EventReplicatorIT {
                 pollInterval, true);
 
         // Then
-        assertThatCode(() -> kafkaAdmin.describeTopics(topicLastIds.keySet().toArray(String[]::new)))
+        assertThatCode(() -> kafkaAdmin.describeTopics(topicLastLsns.keySet().toArray(String[]::new)))
                 .doesNotThrowAnyException();
     }
 
@@ -178,7 +179,7 @@ class EventReplicatorIT {
         // Given
         given(lockManager.acquireLock()).willReturn(true);
 
-        var expectedScheduledTasksCount = topicLastIds.size() + 1; // include lock monitor
+        var expectedScheduledTasksCount = topicLastLsns.size() + 1; // include lock monitor
         var expectedDelay = Duration.ofMillis(pollInterval);
 
         // When
@@ -204,23 +205,23 @@ class EventReplicatorIT {
 
         // store initial progress
         kafkaTemplate.executeInTransaction(kafkaTransaction -> {
-            for (var topicEntry : topicLastIds.entrySet()) {
+            for (var topicEntry : topicLastLsns.entrySet()) {
                 kafkaTransaction.send(
                         PROGRESS_TOPIC,
                         stringToBytes(topicEntry.getKey()),
-                        longToBytes(topicEntry.getValue()));
+                        stringToBytes(topicEntry.getValue()));
             }
 
             return 0;
         });
 
-        var expectedTopicLastIds = topicLastIds
+        var expectedTopicLastLsns = topicLastLsns
                 .entrySet()
                 .stream()
                 .map(topicEntry -> new Tuple(topicEntry.getKey(), topicEntry.getValue()))
                 .toList();
 
-        var expectedScheduledTasksCount = topicLastIds.size() + 1; // include lock monitor
+        var expectedScheduledTasksCount = topicLastLsns.size() + 1; // include lock monitor
         var expectedDelay = Duration.ofMillis(pollInterval);
 
         // When
@@ -242,8 +243,8 @@ class EventReplicatorIT {
 
         assertThat(testedTasks)
                 .describedAs("scheduled tasks")
-                .extracting("replicatedTopic", "lastId")
-                .containsExactlyInAnyOrderElementsOf(expectedTopicLastIds);
+                .extracting("replicatedTopic", "lastLsn")
+                .containsExactlyInAnyOrderElementsOf(expectedTopicLastLsns);
     }
 
     @Test
@@ -256,7 +257,7 @@ class EventReplicatorIT {
         // progress topic is filled
         kafkaTemplate.executeInTransaction(kafkaTransaction -> {
             for (var i = 0; i <= kafkaConsumerMaxPollRecords; i++) {
-                kafkaTransaction.send(PROGRESS_TOPIC, stringToBytes("test_topic"), longToBytes(0l));
+                kafkaTransaction.send(PROGRESS_TOPIC, stringToBytes("test_topic"), stringToBytes("0/0"));
             }
 
             return 0;
@@ -298,12 +299,5 @@ class EventReplicatorIT {
 
     private byte[] stringToBytes(String str) {
         return str.getBytes(StandardCharsets.UTF_8);
-    }
-
-    private byte[] longToBytes(long val) {
-        return ByteBuffer
-                .allocate(Long.BYTES)
-                .putLong(val)
-                .array();
     }
 }

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorWorkerIT.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorWorkerIT.java
@@ -29,10 +29,10 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.kage.event.EventStore.SOURCE_ID;
+import static tech.kage.event.EventStore.SOURCE_LSN;
 import static tech.kage.event.replicator.entity.EventReplicator.PROGRESS_TOPIC;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -128,10 +128,10 @@ abstract class EventReplicatorWorkerIT<K> {
     @Test
     void copiesEventsFromDatabaseToKafkaInSinglePoll() {
         // Given
-        var lastId = 0;
+        var lastLsn = "0/0";
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastId);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, maxPollRows - 1)
@@ -164,35 +164,19 @@ abstract class EventReplicatorWorkerIT<K> {
                             .describedAs("replicated event timestamp")
                             .isEqualTo(sourceEvent.timestamp().toEpochMilli());
 
-                    var expectedHeaderList = sourceEvent
-                            .metadata()
-                            .entrySet()
-                            .stream()
-                            .map(e -> new RecordHeader(e.getKey(), (byte[]) e.getValue()))
-                            .map(Header.class::cast)
-                            .collect(toCollection(ArrayList::new));
-
-                    expectedHeaderList.add(new RecordHeader(SOURCE_ID, Long.toString(sourceEvent.id()).getBytes()));
-
-                    var expectedHeaders = new RecordHeaders(
-                            expectedHeaderList
-                                    .stream()
-                                    .sorted(comparing(Header::key))
-                                    .toList());
-
                     assertThat(replicatedEvent.headers())
                             .describedAs("replicated event headers")
-                            .isEqualTo(expectedHeaders);
+                            .isEqualTo(expectedHeaders(sourceEvent));
                 });
     }
 
     @Test
     void copiesEventsFromDatabaseToKafkaInMultiplePolls() {
         // Given
-        var lastId = 0;
+        var lastLsn = "0/0";
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastId);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, maxPollRows + 1)
@@ -225,35 +209,19 @@ abstract class EventReplicatorWorkerIT<K> {
                             .describedAs("replicated event timestamp")
                             .isEqualTo(sourceEvent.timestamp().toEpochMilli());
 
-                    var expectedHeaderList = sourceEvent
-                            .metadata()
-                            .entrySet()
-                            .stream()
-                            .map(e -> new RecordHeader(e.getKey(), (byte[]) e.getValue()))
-                            .map(Header.class::cast)
-                            .collect(toCollection(ArrayList::new));
-
-                    expectedHeaderList.add(new RecordHeader(SOURCE_ID, Long.toString(sourceEvent.id()).getBytes()));
-
-                    var expectedHeaders = new RecordHeaders(
-                            expectedHeaderList
-                                    .stream()
-                                    .sorted(comparing(Header::key))
-                                    .toList());
-
                     assertThat(replicatedEvent.headers())
                             .describedAs("replicated event headers")
-                            .isEqualTo(expectedHeaders);
+                            .isEqualTo(expectedHeaders(sourceEvent));
                 });
     }
 
     @Test
-    void resumesCopyingEventsFromGivenId() {
+    void resumesCopyingEventsFromGivenLsn() {
         // Given
-        var lastId = 5;
+        var lastLsn = "0/5";
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastId);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, 11)
@@ -265,7 +233,7 @@ abstract class EventReplicatorWorkerIT<K> {
             insertEvent(topic, event);
         }
 
-        var expectedEvents = sourceEvents.subList(lastId, sourceEvents.size());
+        var expectedEvents = sourceEvents.subList(5, sourceEvents.size());
 
         // When
         worker.run();
@@ -288,39 +256,23 @@ abstract class EventReplicatorWorkerIT<K> {
                             .describedAs("replicated event timestamp")
                             .isEqualTo(sourceEvent.timestamp().toEpochMilli());
 
-                    var expectedHeaderList = sourceEvent
-                            .metadata()
-                            .entrySet()
-                            .stream()
-                            .map(e -> new RecordHeader(e.getKey(), (byte[]) e.getValue()))
-                            .map(Header.class::cast)
-                            .collect(toCollection(ArrayList::new));
-
-                    expectedHeaderList.add(new RecordHeader(SOURCE_ID, Long.toString(sourceEvent.id()).getBytes()));
-
-                    var expectedHeaders = new RecordHeaders(
-                            expectedHeaderList
-                                    .stream()
-                                    .sorted(comparing(Header::key))
-                                    .toList());
-
                     assertThat(replicatedEvent.headers())
                             .describedAs("replicated event headers")
-                            .isEqualTo(expectedHeaders);
+                            .isEqualTo(expectedHeaders(sourceEvent));
                 });
     }
 
     @Test
-    void storesLastReplicatedEventId() {
+    void storesLastReplicatedEventLsn() {
         // Given
-        var lastId = 8;
-        var expectedLastId = 23;
+        var lastLsn = "0/8";
+        var expectedLastLsn = "0/17"; // 23 in hex
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastId);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
 
         var sourceEvents = IntStream
-                .rangeClosed(1, expectedLastId)
+                .rangeClosed(1, 23)
                 .boxed()
                 .map(this::testEvent)
                 .toList();
@@ -333,30 +285,29 @@ abstract class EventReplicatorWorkerIT<K> {
         worker.run();
 
         // Then
-        var storedLastId = 0l;
+        String storedLastLsn = null;
 
         var progressRecords = readRecordsFromKafka(PROGRESS_TOPIC);
 
         for (var consumerRecord : progressRecords) {
             if (topic.contains(stringFromBytes(consumerRecord.key()))) {
-                storedLastId = longFromBytes(consumerRecord.value());
+                storedLastLsn = stringFromBytes(consumerRecord.value());
             }
         }
 
-        assertThat(storedLastId)
-                .describedAs("stored last id")
-                .isEqualTo(expectedLastId);
+        assertThat(storedLastLsn)
+                .describedAs("stored last LSN")
+                .isEqualTo(expectedLastLsn);
     }
 
     @Test
     void monitorsReplicationLag() {
         // Given
-        var lastId = 5;
-        var lastSourceId = 13;
+        var lastLsn = "0/5";
         var expectedReplicationLag = 8;
 
         var sourceEvents = IntStream
-                .rangeClosed(1, lastSourceId)
+                .rangeClosed(1, 13)
                 .boxed()
                 .map(this::testEvent)
                 .toList();
@@ -366,7 +317,7 @@ abstract class EventReplicatorWorkerIT<K> {
         }
 
         // When
-        new EventReplicatorWorker(jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastId);
+        new EventReplicatorWorker(jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
 
         // Then
         var replicationLag = meterRegistry.find("event.replicator.lag").tag("topic", topic).gauge().value();
@@ -376,14 +327,33 @@ abstract class EventReplicatorWorkerIT<K> {
                 .isEqualTo(expectedReplicationLag);
     }
 
+    @Test
+    void reportsZeroLagWhenNoEventsHaveLsn() {
+        // Given
+        var lastLsn = "0/0";
+
+        // When
+        new EventReplicatorWorker(
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+
+        // Then
+        var replicationLag = meterRegistry.find("event.replicator.lag").tag("topic", topic).gauge().value();
+
+        assertThat(replicationLag)
+                .describedAs("replication lag")
+                .isEqualTo(0);
+    }
+
     private void insertEvent(String topic, EventData event) {
         jdbcTemplate
                 .update(
-                        "INSERT INTO events." + topic + " (key, data, metadata, timestamp) VALUES (?, ?, ?, ?)",
+                        "INSERT INTO events." + topic
+                                + " (key, data, metadata, timestamp, lsn) VALUES (?, ?, ?, ?, ?::pg_lsn)",
                         event.key(),
                         event.data(),
                         MetadataSerializer.serialize(event.metadata()),
-                        event.timestamp().atOffset(ZoneOffset.UTC));
+                        event.timestamp().atOffset(ZoneOffset.UTC),
+                        event.lsn());
     }
 
     private ConsumerRecords<byte[], byte[]> readRecordsFromKafka(String topic) {
@@ -397,16 +367,27 @@ abstract class EventReplicatorWorkerIT<K> {
         }
     }
 
-    private String stringFromBytes(byte[] bytes) {
-        return new String(bytes, StandardCharsets.UTF_8);
+    private RecordHeaders expectedHeaders(EventData sourceEvent) {
+        var headerList = sourceEvent
+                .metadata()
+                .entrySet()
+                .stream()
+                .map(e -> new RecordHeader(e.getKey(), (byte[]) e.getValue()))
+                .map(Header.class::cast)
+                .collect(toCollection(ArrayList::new));
+
+        headerList.add(new RecordHeader(SOURCE_ID, Long.toString(sourceEvent.id()).getBytes()));
+        headerList.add(new RecordHeader(SOURCE_LSN, sourceEvent.lsn().getBytes()));
+
+        return new RecordHeaders(
+                headerList
+                        .stream()
+                        .sorted(comparing(Header::key))
+                        .toList());
     }
 
-    private long longFromBytes(byte[] bytes) {
-        return ByteBuffer
-                .allocate(Long.BYTES)
-                .put(bytes)
-                .flip()
-                .getLong();
+    private String stringFromBytes(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private EventData testEvent(int id) {
@@ -418,7 +399,8 @@ abstract class EventReplicatorWorkerIT<K> {
                         "dTest", "meta_value".getBytes(),
                         "zTest", UUID.randomUUID().toString().getBytes(),
                         "bTest", Long.toString(id).getBytes()),
-                Instant.now());
+                Instant.now(),
+                "0/" + Integer.toHexString(id).toUpperCase());
     }
 
     protected abstract String getKeyType();
@@ -429,6 +411,7 @@ abstract class EventReplicatorWorkerIT<K> {
         return key.toString().getBytes();
     }
 
-    protected record EventData(long id, Object key, byte[] data, Map<String, Object> metadata, Instant timestamp) {
+    protected record EventData(long id, Object key, byte[] data, Map<String, Object> metadata, Instant timestamp,
+            String lsn) {
     }
 }

--- a/tech.kage.event.replicator/src/test/resources/test-data/events/ddl.sql
+++ b/tech.kage.event.replicator/src/test/resources/test-data/events/ddl.sql
@@ -5,5 +5,8 @@ CREATE TABLE IF NOT EXISTS events.<<topic_name>> (
     key <<key_type>> NOT NULL,
     data bytea NOT NULL,
     metadata bytea,
-    timestamp timestamp with time zone NOT NULL
+    timestamp timestamp with time zone NOT NULL,
+    lsn pg_lsn
 );
+
+CREATE INDEX IF NOT EXISTS <<topic_name>>_lsn_idx ON events.<<topic_name>> (lsn);

--- a/tech.kage.event/src/main/java/tech/kage/event/EventStore.java
+++ b/tech.kage.event/src/main/java/tech/kage/event/EventStore.java
@@ -46,6 +46,12 @@ public interface EventStore<K, V extends SpecificRecord> {
     static final String SOURCE_ID = "id";
 
     /**
+     * Constant representing the event LSN (Log Sequence Number) in the source
+     * database.
+     */
+    static final String SOURCE_LSN = "lsn";
+
+    /**
      * Constant representing the encryption key identifier.
      */
     static final String ENCRYPTION_KEY_ID = "kid";


### PR DESCRIPTION
## Summary

- Add `tech.kage.event.postgres.lsnupdater` module that uses PostgreSQL logical replication to write WAL LSN values back to event rows after insertion
- Switch event replicator from sequential id-based ordering to LSN-based ordering, with progress tracked as LSN and replication lag measured in WAL bytes
- Add `lsn pg_lsn` column and index to the event table schema