### PR TITLE
Bump spring-boot to 3.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.6</version>
+        <version>3.5.13</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Bumps org.springframework.boot:spring-boot-starter-parent from 3.4.6 to 3.5.13.