### PR TITLE
Fix lost events in concurrent and multi-row transactions

### DIFF
--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdater.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdater.java
@@ -45,14 +45,30 @@ import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.BeginMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.CommitMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationMessage;
 
 /**
  * Component that uses PostgreSQL logical replication to update LSN columns in
  * events tables.
- * Connects to an existing replication slot and processes INSERT operations to
- * set the LSN value for each inserted row.
+ * Connects to an existing replication slot and processes BEGIN/INSERT/COMMIT
+ * operations to set the LSN value of every inserted row to its transaction's
+ * commit LSN.
+ * 
+ * <h2>Why commit LSN, not insert LSN</h2>
+ * INSERT records in the WAL are themselves strictly monotonic — Postgres uses
+ * a single global WAL log. However, the pgoutput protocol delivers transactions
+ * to the consumer in commit order, not WAL-write order. So the sequence of
+ * per-INSERT WAL positions <em>as seen by this component</em> can decrease
+ * across consecutive transactions: txn A's INSERT at WAL=100 may arrive after
+ * txn B's INSERT at WAL=110 because B committed first.
+ * Stamping with the per-INSERT WAL position would therefore produce
+ * non-monotonic LSN values in the events table; consumers using
+ * {@code WHERE lsn > :cursor} would silently skip rows whose LSN regressed.
+ * Stamping with the commit LSN (BEGIN.final_lsn) instead gives all rows in a
+ * transaction the same LSN and guarantees monotonicity across transactions.
  * 
  * <h2>Correctness invariants</h2>
  * <ul>
@@ -104,6 +120,13 @@ class LsnUpdater {
     private Thread replicationThread;
     private Connection replicationConnection;
     private PGReplicationStream replicationStream;
+
+    /**
+     * Commit LSN of the currently-open transaction in the replication stream;
+     * {@code null} when not inside a transaction. Set on BEGIN, used to stamp
+     * each INSERT in the txn, cleared on COMMIT.
+     */
+    private Long currentTxnLsn;
 
     /**
      * Constructs a new {@link LsnUpdater} instance.
@@ -220,40 +243,50 @@ class LsnUpdater {
      * @param message replication payload buffer read from the stream
      */
     private void processMessage(ByteBuffer message) {
-        var messageInfo = parser.parse(message);
+        var parsed = parser.parse(message);
 
-        if (messageInfo != null && messageInfo.type() == MessageType.INSERT) {
-            processInsert(messageInfo);
+        switch (parsed) {
+            case BeginMessage begin -> currentTxnLsn = begin.finalLsn();
+            case InsertMessage insert -> processInsert(insert);
+            case CommitMessage commit -> {
+                if (currentTxnLsn == null || currentTxnLsn.longValue() != commit.commitLsn()) {
+                    throw new IllegalStateException(
+                            "COMMIT commitLsn=" + commit.commitLsn()
+                                    + " does not match open transaction's BEGIN.finalLsn=" + currentTxnLsn);
+                }
+                currentTxnLsn = null;
+            }
+            case RelationMessage relation -> {
+                // Relation metadata is cached inside the parser; nothing to do here.
+            }
+            case null -> {
+                // Unhandled message type; pgoutput protocol allows skipping.
+            }
         }
     }
 
     /**
-     * Processes an INSERT message and updates the LSN column.
-     *
-     * @param messageInfo parsed replication message details
+     * Processes an INSERT message and updates the LSN column with the current
+     * transaction's commit LSN.
+     * 
+     * @param insert parsed INSERT message
      */
-    private void processInsert(MessageInfo messageInfo) {
-        var relationInfo = messageInfo.relationInfo();
-        var insertInfo = messageInfo.insertInfo();
+    private void processInsert(InsertMessage insert) {
+        var relationInfo = insert.relation();
 
         // Only process tables ending with _events suffix
         if (!relationInfo.table().endsWith(TOPIC_SUFFIX)) {
             return;
         }
 
-        // Get the id value from the INSERT
-        var id = insertInfo.idValue();
-
-        if (id == null) {
+        if (currentTxnLsn == null) {
             throw new IllegalStateException(
-                    "INSERT for " + relationInfo.schema() + "." + relationInfo.table() + " is missing id value");
+                    "INSERT for " + relationInfo.schema() + "." + relationInfo.table()
+                            + " received outside of an open transaction (no BEGIN seen)");
         }
 
-        // Get LSN from the replication stream
-        var lsn = replicationStream.getLastReceiveLSN();
-
         // Update the LSN column
-        updateLsn(relationInfo.schema(), relationInfo.table(), id, lsn.asString());
+        updateLsn(relationInfo.schema(), relationInfo.table(), insert.id(), lsnToText(currentTxnLsn));
     }
 
     /**
@@ -264,7 +297,7 @@ class LsnUpdater {
      * @param id     row identifier to update
      * @param lsn    WAL location to persist in the row
      */
-    private void updateLsn(String schema, String table, Long id, String lsn) {
+    private void updateLsn(String schema, String table, long id, String lsn) {
         var sql = UPDATE_LSN_SQL.formatted(schema, table);
 
         var rowsUpdated = jdbcTemplate.update(sql, lsn, id);
@@ -275,6 +308,18 @@ class LsnUpdater {
         }
 
         log.debug("Updated LSN for {}.{} id={} to {}", schema, table, id, lsn);
+    }
+
+    /**
+     * Formats a 64-bit LSN as Postgres' canonical {@code "X/Y"} text form (high
+     * 32 bits / low 32 bits in uppercase hexadecimal).
+     * 
+     * @param lsn 64-bit WAL location
+     * 
+     * @return canonical {@code "X/Y"} text form of the LSN
+     */
+    private static String lsnToText(long lsn) {
+        return String.format("%X/%X", lsn >>> 32, lsn & 0xFFFFFFFFL);
     }
 
     // Added for testability

--- a/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParser.java
+++ b/tech.kage.event.postgres.lsnupdater/src/main/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParser.java
@@ -16,7 +16,7 @@
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCESSING OF SUBSTITUTE GOODS OR
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
@@ -35,7 +35,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * Parser for PostgreSQL pgoutput binary protocol messages.
- * Handles RELATION and INSERT messages, skips other message types.
+ * Handles BEGIN, COMMIT, RELATION and INSERT messages, skips other message
+ * types.
  * 
  * <p>
  * The parser assumes a fixed event table schema where {@code id} is always
@@ -52,6 +53,16 @@ import org.springframework.stereotype.Component;
  */
 @Component
 class PgOutputMessageParser {
+    /**
+     * Message type byte for BEGIN.
+     */
+    private static final byte MESSAGE_TYPE_BEGIN = 'B';
+
+    /**
+     * Message type byte for COMMIT.
+     */
+    private static final byte MESSAGE_TYPE_COMMIT = 'C';
+
     /**
      * Message type byte for RELATION (table metadata).
      */
@@ -72,9 +83,9 @@ class PgOutputMessageParser {
      * 
      * @param buffer the ByteBuffer containing the message
      * 
-     * @return parsed message info, or null if message type is not handled
+     * @return parsed message, or null if message type is not handled
      */
-    MessageInfo parse(ByteBuffer buffer) {
+    PgOutputMessage parse(ByteBuffer buffer) {
         if (buffer.remaining() < 1) {
             return null;
         }
@@ -82,10 +93,58 @@ class PgOutputMessageParser {
         var messageType = buffer.get();
 
         return switch (messageType) {
+            case MESSAGE_TYPE_BEGIN -> parseBegin(buffer);
+            case MESSAGE_TYPE_COMMIT -> parseCommit(buffer);
             case MESSAGE_TYPE_RELATION -> parseRelation(buffer);
             case MESSAGE_TYPE_INSERT -> parseInsert(buffer);
             default -> null;
         };
+    }
+
+    /**
+     * Parses a BEGIN message.
+     * Format: final_lsn (8 bytes, big-endian), commit_timestamp (8 bytes,
+     * big-endian), xid (4 bytes, big-endian).
+     * 
+     * <p>
+     * In pgoutput v1 with non-streaming transactions, {@code final_lsn} equals
+     * the eventual commit LSN of the transaction. The walsender knows this value
+     * before emitting BEGIN because the entire transaction has already been
+     * decoded from the WAL.
+     * 
+     * @param buffer byte buffer containing the BEGIN message payload
+     * 
+     * @return parsed BEGIN message
+     */
+    private BeginMessage parseBegin(ByteBuffer buffer) {
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        var finalLsn = buffer.getLong();
+        var commitTimestamp = buffer.getLong();
+        var xid = buffer.getInt();
+
+        return new BeginMessage(finalLsn, commitTimestamp, xid);
+    }
+
+    /**
+     * Parses a COMMIT message.
+     * Format: flags (1 byte), commit_lsn (8 bytes, big-endian), end_lsn (8 bytes,
+     * big-endian), commit_timestamp (8 bytes, big-endian).
+     * 
+     * @param buffer byte buffer containing the COMMIT message payload
+     * 
+     * @return parsed COMMIT message
+     */
+    private CommitMessage parseCommit(ByteBuffer buffer) {
+        var flags = buffer.get();
+
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        var commitLsn = buffer.getLong();
+        var endLsn = buffer.getLong();
+        var commitTimestamp = buffer.getLong();
+
+        return new CommitMessage(flags, commitLsn, endLsn, commitTimestamp);
     }
 
     /**
@@ -96,9 +155,9 @@ class PgOutputMessageParser {
      * 
      * @param buffer byte buffer containing the RELATION message payload
      * 
-     * @return parsed relation message information
+     * @return parsed RELATION message
      */
-    private MessageInfo parseRelation(ByteBuffer buffer) {
+    private RelationMessage parseRelation(ByteBuffer buffer) {
         buffer.order(ByteOrder.BIG_ENDIAN);
 
         var relationId = buffer.getInt();
@@ -111,7 +170,7 @@ class PgOutputMessageParser {
 
         relations.put(relationId, relationInfo);
 
-        return new MessageInfo(MessageType.RELATION, relationInfo, null);
+        return new RelationMessage(relationInfo);
     }
 
     /**
@@ -120,9 +179,9 @@ class PgOutputMessageParser {
      * 
      * @param buffer byte buffer containing the INSERT message payload
      * 
-     * @return parsed insert message information
+     * @return parsed INSERT message
      */
-    private MessageInfo parseInsert(ByteBuffer buffer) {
+    private InsertMessage parseInsert(ByteBuffer buffer) {
         buffer.order(ByteOrder.BIG_ENDIAN);
 
         var relationId = buffer.getInt();
@@ -136,7 +195,7 @@ class PgOutputMessageParser {
 
         var idValue = parseIdValue(buffer);
 
-        return new MessageInfo(MessageType.INSERT, relationInfo, new InsertInfo(relationId, idValue));
+        return new InsertMessage(relationInfo, idValue);
     }
 
     /**
@@ -148,9 +207,9 @@ class PgOutputMessageParser {
      * 
      * @param buffer byte buffer containing tuple data
      * 
-     * @return the id value as Long
+     * @return the id value
      */
-    private Long parseIdValue(ByteBuffer buffer) {
+    private long parseIdValue(ByteBuffer buffer) {
         var tupleType = buffer.get();
 
         if (tupleType != 'N') { // 'N' for new tuple
@@ -201,21 +260,50 @@ class PgOutputMessageParser {
     }
 
     /**
-     * Message type enumeration.
+     * Parsed pgoutput message.
      */
-    enum MessageType {
-        RELATION,
-        INSERT
+    sealed interface PgOutputMessage permits BeginMessage, CommitMessage, RelationMessage, InsertMessage {
     }
 
     /**
-     * Container for parsed message information.
+     * BEGIN message marking the start of a transaction in the replication stream.
      * 
-     * @param type         parsed message type
-     * @param relationInfo relation metadata extracted from the message
-     * @param insertInfo   insert metadata extracted from the message
+     * @param finalLsn        commit LSN of the transaction (known up front because
+     *                        the walsender has already decoded the COMMIT record)
+     * @param commitTimestamp commit timestamp in microseconds since 2000-01-01 UTC
+     * @param xid             transaction id
      */
-    static record MessageInfo(MessageType type, RelationInfo relationInfo, InsertInfo insertInfo) {
+    record BeginMessage(long finalLsn, long commitTimestamp, int xid) implements PgOutputMessage {
+    }
+
+    /**
+     * COMMIT message marking the end of a transaction in the replication stream.
+     * 
+     * @param flags           commit flags (must be 0 in pgoutput v1)
+     * @param commitLsn       LSN of the commit record (must equal the matching
+     *                        BEGIN's finalLsn)
+     * @param endLsn          LSN immediately after the commit record
+     * @param commitTimestamp commit timestamp in microseconds since 2000-01-01 UTC
+     */
+    record CommitMessage(byte flags, long commitLsn, long endLsn, long commitTimestamp) implements PgOutputMessage {
+    }
+
+    /**
+     * RELATION message describing a table's schema.
+     * 
+     * @param relation parsed relation metadata (cached for use by subsequent
+     *                 INSERT messages referencing the same relation OID)
+     */
+    record RelationMessage(RelationInfo relation) implements PgOutputMessage {
+    }
+
+    /**
+     * INSERT message describing a single inserted row.
+     * 
+     * @param relation relation the row was inserted into
+     * @param id       parsed id column value
+     */
+    record InsertMessage(RelationInfo relation, long id) implements PgOutputMessage {
     }
 
     /**
@@ -225,15 +313,6 @@ class PgOutputMessageParser {
      * @param schema     relation schema name
      * @param table      relation table name
      */
-    static record RelationInfo(int relationId, String schema, String table) {
-    }
-
-    /**
-     * Information about an INSERT operation.
-     * 
-     * @param relationId internal relation identifier from pgoutput
-     * @param idValue    parsed id column value
-     */
-    static record InsertInfo(int relationId, Long idValue) {
+    record RelationInfo(int relationId, String schema, String table) {
     }
 }

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterErrorHandlingIT.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterErrorHandlingIT.java
@@ -57,9 +57,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertInfo;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.BeginMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.CommitMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertMessage;
 import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationInfo;
 
 /**
@@ -129,19 +129,18 @@ class LsnUpdaterErrorHandlingIT {
     }
 
     @Test
-    void terminatesProcessWhenInsertHasNullId() {
+    void terminatesProcessWhenInsertReceivedOutsideOfTransaction() {
         // Given
         given(parser.parse(any())).willAnswer(invocation -> {
             ByteBuffer buf = invocation.getArgument(0);
             byte type = buf.get(buf.position());
 
             if (type == 'I') {
-                return new MessageInfo(
-                        MessageType.INSERT,
-                        new RelationInfo(1, "events", "test_events"),
-                        new InsertInfo(1, null));
+                return new InsertMessage(new RelationInfo(1, "events", "test_events"), 123L);
             }
 
+            // Skip BEGIN/COMMIT so currentTxnLsn stays null and the INSERT
+            // hits the "no BEGIN seen" guard.
             return null;
         });
 
@@ -166,18 +165,70 @@ class LsnUpdaterErrorHandlingIT {
             ByteBuffer buf = invocation.getArgument(0);
             byte type = buf.get(buf.position());
 
-            if (type == 'I') {
-                return new MessageInfo(
-                        MessageType.INSERT,
-                        new RelationInfo(1, "events", "test_events"),
-                        new InsertInfo(1, 123L));
-            }
-
-            return null;
+            return switch ((char) type) {
+                case 'B' -> new BeginMessage(0x100L, 0L, 1);
+                case 'C' -> new CommitMessage((byte) 0, 0x100L, 0x108L, 0L);
+                case 'I' -> new InsertMessage(new RelationInfo(1, "events", "test_events"), 123L);
+                default -> null;
+            };
         });
 
         // When
         insertTestEvent("44444444-4444-4444-4444-444444444444");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(1));
+    }
+
+    @Test
+    void terminatesProcessWhenCommitReceivedOutsideOfTransaction() {
+        // Given
+        given(parser.parse(any())).willAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte type = buf.get(buf.position());
+
+            // Skip BEGIN so currentTxnLsn stays null and the COMMIT
+            // hits the "no open transaction" guard.
+            return switch ((char) type) {
+                case 'C' -> new CommitMessage((byte) 0, 0x100L, 0x108L, 0L);
+                default -> null;
+            };
+        });
+
+        // When
+        insertTestEvent("55555555-5555-5555-5555-555555555555");
+
+        // Then
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(lsnUpdater.getLastExitCode())
+                        .describedAs("exit code")
+                        .isEqualTo(1));
+    }
+
+    @Test
+    void terminatesProcessWhenCommitLsnDoesNotMatchOpenTransaction() {
+        // Given
+        given(parser.parse(any())).willAnswer(invocation -> {
+            ByteBuffer buf = invocation.getArgument(0);
+            byte type = buf.get(buf.position());
+
+            return switch ((char) type) {
+                case 'B' -> new BeginMessage(0x100L, 0L, 1);
+                // Mismatched commitLsn (0x999) vs BEGIN.finalLsn (0x100).
+                case 'C' -> new CommitMessage((byte) 0, 0x999L, 0x108L, 0L);
+                default -> null;
+            };
+        });
+
+        // When
+        insertTestEvent("66666666-6666-6666-6666-666666666666");
 
         // Then
         await()
@@ -196,10 +247,7 @@ class LsnUpdaterErrorHandlingIT {
             byte type = buf.get(buf.position());
 
             if (type == 'I') {
-                return new MessageInfo(
-                        MessageType.INSERT,
-                        new RelationInfo(1, "events", "some_other_table"),
-                        new InsertInfo(1, 123L));
+                return new InsertMessage(new RelationInfo(1, "events", "some_other_table"), 123L);
             }
 
             return null;

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterIT.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/LsnUpdaterIT.java
@@ -28,7 +28,11 @@ package tech.kage.event.postgres.lsnupdater.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Duration;
+
+import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -67,6 +71,9 @@ class LsnUpdaterIT {
 
     @Autowired
     JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    DataSource dataSource;
 
     @SuppressWarnings("resource")
     @Container
@@ -124,18 +131,26 @@ class LsnUpdaterIT {
 
     @Test
     @Order(2)
-    void updatesLsnForMultipleInsertedRows() {
+    void stampsAllRowsOfMultiInsertTxnWithSameCommitLsn() throws SQLException {
         // Given
-        // LsnUpdater is running via Spring context
+        // LsnUpdater is running via Spring context. We drive an explicit
+        // transaction with three separate INSERT statements to simulate the
+        // downstream usage pattern of composing multiple save() calls under
+        // one TransactionalOperator.
+        long id1;
+        long id2;
+        long id3;
 
         // When
-        var ids = jdbcTemplate.queryForList("""
-                INSERT INTO events.test_events (key, data, metadata, timestamp)
-                VALUES ('22222222-2222-2222-2222-222222222222', decode('BB', 'hex'), null, now()),
-                       ('33333333-3333-3333-3333-333333333333', decode('CC', 'hex'), null, now()),
-                       ('44444444-4444-4444-4444-444444444444', decode('DD', 'hex'), null, now())
-                RETURNING id
-                """, Long.class);
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+
+            id1 = insertOneAndReturnId(conn, "22222222-2222-2222-2222-222222222222", (byte) 0xBB);
+            id2 = insertOneAndReturnId(conn, "33333333-3333-3333-3333-333333333333", (byte) 0xCC);
+            id3 = insertOneAndReturnId(conn, "44444444-4444-4444-4444-444444444444", (byte) 0xDD);
+
+            conn.commit();
+        }
 
         // Then
         await()
@@ -143,18 +158,85 @@ class LsnUpdaterIT {
                 .pollInterval(Duration.ofMillis(100))
                 .untilAsserted(() -> {
                     var lsnValues = jdbcTemplate.queryForList(
-                            "SELECT lsn::text FROM events.test_events WHERE id IN (?, ?, ?)",
+                            "SELECT lsn::text FROM events.test_events WHERE id IN (?, ?, ?) ORDER BY id",
                             String.class,
-                            ids.get(0), ids.get(1), ids.get(2));
+                            id1, id2, id3);
 
                     assertThat(lsnValues)
+                            .describedAs("lsns for rows of multi-insert txn")
                             .hasSize(3)
                             .doesNotContainNull();
+
+                    assertThat(lsnValues)
+                            .describedAs("all rows of one txn share the same commit LSN")
+                            .containsOnly(lsnValues.get(0));
                 });
     }
 
     @Test
     @Order(3)
+    void stampsCommitLsnNotInsertLsnUnderConcurrentTxns() throws SQLException {
+        // Given
+        // Drive a commit-reorder pattern: txn A inserts first (lower WAL
+        // position) but commits last; txn B inserts second but commits first.
+        // With commit-LSN stamping, the row inserted by B (committed first)
+        // must have a smaller lsn than the row inserted by A. With insert-LSN
+        // stamping the relation would be reversed.
+        long idA;
+        long idB;
+
+        // When
+        try (var connA = dataSource.getConnection(); var connB = dataSource.getConnection()) {
+            connA.setAutoCommit(false);
+            connB.setAutoCommit(false);
+
+            // 1. Conn-A: INSERT (writes WAL first).
+            idA = insertOneAndReturnId(connA, "55555555-5555-5555-5555-555555555555", (byte) 0xAA);
+
+            // 2. Conn-B: INSERT (writes WAL after A).
+            idB = insertOneAndReturnId(connB, "66666666-6666-6666-6666-666666666666", (byte) 0xBB);
+
+            // 3. Conn-B: COMMIT (commits before A despite later INSERT).
+            connB.commit();
+
+            // 4. Conn-A: COMMIT (commits after B).
+            connA.commit();
+        }
+
+        // Then
+        var finalIdA = idA;
+        var finalIdB = idB;
+
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> {
+                    var lsnB = jdbcTemplate.queryForObject(
+                            "SELECT lsn::text FROM events.test_events WHERE id = ?",
+                            String.class,
+                            finalIdB);
+                    var lsnA = jdbcTemplate.queryForObject(
+                            "SELECT lsn::text FROM events.test_events WHERE id = ?",
+                            String.class,
+                            finalIdA);
+
+                    assertThat(lsnA).describedAs("lsn for row inserted by A").isNotNull();
+                    assertThat(lsnB).describedAs("lsn for row inserted by B").isNotNull();
+
+                    var bIsLessThanA = jdbcTemplate.queryForObject(
+                            "SELECT (?::pg_lsn < ?::pg_lsn)",
+                            Boolean.class,
+                            lsnB, lsnA);
+
+                    assertThat(bIsLessThanA)
+                            .describedAs("lsn of B's row (committed first) < lsn of A's row — got B=%s, A=%s",
+                                    lsnB, lsnA)
+                            .isTrue();
+                });
+    }
+
+    @Test
+    @Order(4)
     void stopsProcessingAfterDestroy() throws Exception {
         // Given
         // LsnUpdater is running via Spring context
@@ -165,7 +247,7 @@ class LsnUpdaterIT {
         // Then
         var id = jdbcTemplate.queryForObject("""
                 INSERT INTO events.test_events (key, data, metadata, timestamp)
-                VALUES ('55555555-5555-5555-5555-555555555555', decode('EE', 'hex'), null, now())
+                VALUES ('77777777-7777-7777-7777-777777777777', decode('EE', 'hex'), null, now())
                 RETURNING id
                 """, Long.class);
 
@@ -183,5 +265,22 @@ class LsnUpdaterIT {
                             .describedAs("lsn for id %d after destroy", id)
                             .isNull();
                 });
+    }
+
+    private long insertOneAndReturnId(Connection conn, String key, byte data) throws SQLException {
+        try (var stmt = conn.prepareStatement("""
+                INSERT INTO events.test_events (key, data, metadata, timestamp)
+                VALUES (?::uuid, ?, null, now())
+                RETURNING id
+                """)) {
+            stmt.setString(1, key);
+            stmt.setBytes(2, new byte[] { data });
+
+            try (var rs = stmt.executeQuery()) {
+                rs.next();
+
+                return rs.getLong(1);
+            }
+        }
     }
 }

--- a/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParserTest.java
+++ b/tech.kage.event.postgres.lsnupdater/src/test/java/tech/kage/event/postgres/lsnupdater/entity/PgOutputMessageParserTest.java
@@ -43,10 +43,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertInfo;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageInfo;
-import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.MessageType;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.BeginMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.CommitMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.InsertMessage;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.PgOutputMessage;
 import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationInfo;
+import tech.kage.event.postgres.lsnupdater.entity.PgOutputMessageParser.RelationMessage;
 
 /**
  * Tests of {@link PgOutputMessageParser}.
@@ -58,14 +60,39 @@ class PgOutputMessageParserTest {
     PgOutputMessageParser parser = new PgOutputMessageParser();
 
     @Test
+    void parsesBeginMessages() throws IOException {
+        // Given
+        var buffer = buildBeginMessage(0x12A4B5CL, 1234567890L, 42);
+
+        var expected = new BeginMessage(0x12A4B5CL, 1234567890L, 42);
+
+        // When
+        var result = parser.parse(buffer);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void parsesCommitMessages() throws IOException {
+        // Given
+        var buffer = buildCommitMessage((byte) 0, 0x12A4B5CL, 0x12A4B60L, 1234567890L);
+
+        var expected = new CommitMessage((byte) 0, 0x12A4B5CL, 0x12A4B60L, 1234567890L);
+
+        // When
+        var result = parser.parse(buffer);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
     void parsesRelationMessages() throws IOException {
         // Given
         var buffer = buildRelationMessage(12345, "events", "user_events", "id", "key", "data");
 
-        var expected = new MessageInfo(
-                MessageType.RELATION,
-                new RelationInfo(12345, "events", "user_events"),
-                null);
+        var expected = new RelationMessage(new RelationInfo(12345, "events", "user_events"));
 
         // When
         var result = parser.parse(buffer);
@@ -76,8 +103,8 @@ class PgOutputMessageParserTest {
 
     @ParameterizedTest
     @MethodSource("testInsertMessagesWithKnownRelation")
-    void parsesInsertMessagesWithKnownRelation(ByteBuffer relationBuffer, ByteBuffer insertBuffer, MessageInfo expected)
-            throws IOException {
+    void parsesInsertMessagesWithKnownRelation(ByteBuffer relationBuffer, ByteBuffer insertBuffer,
+            PgOutputMessage expected) throws IOException {
         // Given
         parser.parse(relationBuffer); // Parse RELATION message first to register relation metadata in the parser
 
@@ -94,18 +121,12 @@ class PgOutputMessageParserTest {
                         named("insert with id at first position",
                                 buildRelationMessage(100, "events", "test_events", "id", "key", "data")),
                         buildInsertMessage(100, "42"),
-                        new MessageInfo(
-                                MessageType.INSERT,
-                                new RelationInfo(100, "events", "test_events"),
-                                new InsertInfo(100, 42L))),
+                        new InsertMessage(new RelationInfo(100, "events", "test_events"), 42L)),
                 arguments(
                         named("insert with large id value",
                                 buildRelationMessage(300, "events", "big_events", "id")),
                         buildInsertMessage(300, "9223372036854775807"),
-                        new MessageInfo(
-                                MessageType.INSERT,
-                                new RelationInfo(300, "events", "big_events"),
-                                new InsertInfo(300, Long.MAX_VALUE))));
+                        new InsertMessage(new RelationInfo(300, "events", "big_events"), Long.MAX_VALUE)));
     }
 
     @Test
@@ -121,14 +142,8 @@ class PgOutputMessageParserTest {
         var inserts = List.of(buildInsertMessage(1, "100"), buildInsertMessage(2, "200"));
 
         var expected = List.of(
-                new MessageInfo(
-                        MessageType.INSERT,
-                        new RelationInfo(1, "events", "events_a"),
-                        new InsertInfo(1, 100L)),
-                new MessageInfo(
-                        MessageType.INSERT,
-                        new RelationInfo(2, "events", "events_b"),
-                        new InsertInfo(2, 200L)));
+                new InsertMessage(new RelationInfo(1, "events", "events_a"), 100L),
+                new InsertMessage(new RelationInfo(2, "events", "events_b"), 200L));
 
         // When
         var results = inserts.stream().map(parser::parse).toList();
@@ -204,8 +219,42 @@ class PgOutputMessageParserTest {
         return Stream.of(
                 arguments(named("empty buffer", ByteBuffer.allocate(0))),
                 arguments(named("unknown message type 'X'", ByteBuffer.allocate(1).put((byte) 'X').flip())),
-                arguments(named("BEGIN message", ByteBuffer.allocate(1).put((byte) 'B').flip())),
-                arguments(named("COMMIT message", ByteBuffer.allocate(1).put((byte) 'C').flip())));
+                arguments(named("ORIGIN message", ByteBuffer.allocate(1).put((byte) 'O').flip())),
+                arguments(named("TRUNCATE message", ByteBuffer.allocate(1).put((byte) 'T').flip())));
+    }
+
+    /**
+     * Builds a BEGIN message buffer.
+     * Format: 'B' (1 byte), final_lsn (8 bytes), commit_timestamp (8 bytes),
+     * xid (4 bytes).
+     */
+    private static ByteBuffer buildBeginMessage(long finalLsn, long commitTimestamp, int xid) throws IOException {
+        var out = new ByteArrayOutputStream();
+
+        out.write('B');
+        out.write(toBytes(finalLsn));
+        out.write(toBytes(commitTimestamp));
+        out.write(toBytes(xid));
+
+        return ByteBuffer.wrap(out.toByteArray());
+    }
+
+    /**
+     * Builds a COMMIT message buffer.
+     * Format: 'C' (1 byte), flags (1 byte), commit_lsn (8 bytes), end_lsn (8
+     * bytes), commit_timestamp (8 bytes).
+     */
+    private static ByteBuffer buildCommitMessage(byte flags, long commitLsn, long endLsn, long commitTimestamp)
+            throws IOException {
+        var out = new ByteArrayOutputStream();
+
+        out.write('C');
+        out.write(flags);
+        out.write(toBytes(commitLsn));
+        out.write(toBytes(endLsn));
+        out.write(toBytes(commitTimestamp));
+
+        return ByteBuffer.wrap(out.toByteArray());
     }
 
     /**
@@ -290,5 +339,12 @@ class PgOutputMessageParserTest {
      */
     private static byte[] toBytes(int value) {
         return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(value).array();
+    }
+
+    /**
+     * Converts a long to 8 bytes in big-endian order.
+     */
+    private static byte[] toBytes(long value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(value).array();
     }
 }

--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Dariusz Szpakowski
+ * Copyright (c) 2023-2026, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import tech.kage.event.replicator.entity.EventReplicatorWorker.Cursor;
 
 /**
  * Component responsible for coordination of event replication process. Uses
@@ -156,18 +157,18 @@ class EventReplicator {
         // create progress Kafka topic
         kafkaAdmin.createOrModifyTopics(TopicBuilder.name(PROGRESS_TOPIC).partitions(1).compact().build());
 
-        log.info("Reading last replicated event LSNs...");
+        log.info("Reading last replicated event cursors...");
 
-        // read last replicated event LSNs (map topic->lsn)
-        var lastLsns = readLastLsns(getReplicatedTopics(jdbcTemplate), consumerFactory);
+        // read last replicated event cursors (map topic->cursor)
+        var lastCursors = readLastCursors(getReplicatedTopics(jdbcTemplate), consumerFactory);
 
         log.info("Scheduling workers...");
 
         // for each replicated topic
-        for (var lastLsn : lastLsns.entrySet()) {
+        for (var entry : lastCursors.entrySet()) {
             // create replicated Kafka topic
             kafkaAdmin.createOrModifyTopics(
-                    TopicBuilder.name(lastLsn.getKey()).config(TopicConfig.RETENTION_MS_CONFIG, "-1").build());
+                    TopicBuilder.name(entry.getKey()).config(TopicConfig.RETENTION_MS_CONFIG, "-1").build());
 
             // schedule a new worker for the replicated topic
             taskScheduler.scheduleWithFixedDelay(
@@ -177,8 +178,8 @@ class EventReplicator {
                             meterRegistry,
                             environment,
                             eventSchema,
-                            lastLsn.getKey(),
-                            lastLsn.getValue()),
+                            entry.getKey(),
+                            entry.getValue()),
                     Duration.ofMillis(pollInterval));
         }
 
@@ -203,20 +204,21 @@ class EventReplicator {
     }
 
     /**
-     * Reads the last replicated LSNs for each topic from the progress Kafka topic.
+     * Reads the last replicated cursors for each topic from the progress Kafka
+     * topic.
      * 
      * @param replicatedTopics a list of replicated topics
      * @param consumerFactory  an instance of {@link ConsumerFactory}
      * 
-     * @return map of topics with the LSNs of the last replicated events
+     * @return map of topics with the cursors of the last replicated events
      */
-    private Map<String, String> readLastLsns(
+    private Map<String, Cursor> readLastCursors(
             List<String> replicatedTopics,
             ConsumerFactory<byte[], byte[]> consumerFactory) {
-        var lastLsns = new HashMap<String, String>();
+        var lastCursors = new HashMap<String, Cursor>();
 
         for (var topic : replicatedTopics) {
-            lastLsns.put(topic, "0/0");
+            lastCursors.put(topic, Cursor.INITIAL);
         }
 
         var topicPartition = List.of(new TopicPartition(PROGRESS_TOPIC, 0));
@@ -239,7 +241,7 @@ class EventReplicator {
                 var topic = stringFromBytes(consumerRecord.key());
 
                 if (replicatedTopics.contains(topic)) {
-                    lastLsns.put(topic, stringFromBytes(consumerRecord.value()));
+                    lastCursors.put(topic, Cursor.fromProgressValue(stringFromBytes(consumerRecord.value())));
                 }
             }
 
@@ -250,7 +252,7 @@ class EventReplicator {
             }
         }
 
-        return lastLsns;
+        return lastCursors;
     }
 
     private byte[] stringToBytes(String str) {

--- a/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicatorWorker.java
+++ b/tech.kage.event.replicator/src/main/java/tech/kage/event/replicator/entity/EventReplicatorWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Dariusz Szpakowski
+ * Copyright (c) 2023-2026, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,6 +50,13 @@ import tech.kage.event.crypto.MetadataSerializer;
  * Worker component responsible for replicating events from a single event table
  * to a single Kafka topic.
  * 
+ * <p>
+ * The replication cursor is a {@code (lsn, id)} pair compared via Postgres
+ * row-value semantics. The {@code id} component is required because rows
+ * inserted in a single transaction share the same commit LSN; an LSN-only
+ * cursor would silently skip same-LSN siblings whenever a transaction's row
+ * count crosses the batch {@code LIMIT}.
+ * 
  * @author Dariusz Szpakowski
  */
 class EventReplicatorWorker implements Runnable {
@@ -59,8 +66,8 @@ class EventReplicatorWorker implements Runnable {
     private static final String SELECT_EVENT_SQL = """
                 SELECT *
                 FROM %s.%s
-                WHERE lsn IS NOT NULL AND lsn > '%s'::pg_lsn
-                ORDER BY lsn
+                WHERE lsn IS NOT NULL AND (lsn, id) > ('%s'::pg_lsn, %d)
+                ORDER BY lsn, id
                 LIMIT %s
             """;
 
@@ -97,7 +104,7 @@ class EventReplicatorWorker implements Runnable {
     private final String replicatedTopic;
     private final int maxRows;
 
-    private String lastLsn;
+    private Cursor lastCursor;
 
     /**
      * Constructs a new {@link EventReplicatorWorker} instance.
@@ -108,8 +115,8 @@ class EventReplicatorWorker implements Runnable {
      * @param environment     an instance of {@link Environment}
      * @param eventSchema     the name of the event schema
      * @param replicatedTopic the name of the replicated topic
-     * @param lastLsn         the LSN of the last replicated event in the replicated
-     *                        topic
+     * @param lastCursor      the cursor of the last replicated event in the
+     *                        replicated topic
      */
     EventReplicatorWorker(
             JdbcTemplate jdbcTemplate,
@@ -118,7 +125,7 @@ class EventReplicatorWorker implements Runnable {
             Environment environment,
             String eventSchema,
             String replicatedTopic,
-            String lastLsn) {
+            Cursor lastCursor) {
         this.jdbcTemplate = jdbcTemplate;
         this.kafkaTemplate = kafkaTemplate;
 
@@ -126,7 +133,7 @@ class EventReplicatorWorker implements Runnable {
         this.replicatedTopic = replicatedTopic;
         this.maxRows = environment.getProperty(MAX_ROWS_PROPERTY, Integer.class, 100);
 
-        this.lastLsn = lastLsn;
+        this.lastCursor = lastCursor;
 
         Gauge
                 .builder(MICROMETER_LAG_GAUGE_NAME, this, worker -> worker.computeLag())
@@ -141,10 +148,10 @@ class EventReplicatorWorker implements Runnable {
     @Override
     public void run() {
         while (true) {
-            var updatedLastLsn = pollAndSendBatch(eventSchema, replicatedTopic, lastLsn, maxRows);
+            var updatedLastCursor = pollAndSendBatch(eventSchema, replicatedTopic, lastCursor, maxRows);
 
-            if (updatedLastLsn != null) {
-                lastLsn = updatedLastLsn;
+            if (updatedLastCursor != null) {
+                lastCursor = updatedLastCursor;
             } else {
                 // no more events found so we are done
                 return;
@@ -156,17 +163,18 @@ class EventReplicatorWorker implements Runnable {
      * Polls the event table and sends read events to the Kafka topic with the same
      * name.
      * 
-     * @param schema    the name of the event schema
-     * @param topic     the name of the replicated topic
-     * @param lastLsn   the LSN of the last replicated event in the replicated
-     *                  topic
-     * @param batchSize maximum number of events replicated in one batch.
+     * @param schema     the name of the event schema
+     * @param topic      the name of the replicated topic
+     * @param lastCursor the cursor of the last replicated event in the replicated
+     *                   topic
+     * @param batchSize  maximum number of events replicated in one batch.
      * 
-     * @return LSN of the last replicated event or null if no events were found
+     * @return cursor of the last replicated event or null if no events were found
      */
-    private String pollAndSendBatch(String schema, String topic, String lastLsn, int batchSize) {
+    private Cursor pollAndSendBatch(String schema, String topic, Cursor lastCursor, int batchSize) {
         // select the events for replication
-        var eventList = jdbcTemplate.queryForList(SELECT_EVENT_SQL.formatted(schema, topic, lastLsn, batchSize));
+        var eventList = jdbcTemplate.queryForList(
+                SELECT_EVENT_SQL.formatted(schema, topic, lastCursor.lsn(), lastCursor.id(), batchSize));
 
         if (eventList.isEmpty()) {
             return null;
@@ -174,26 +182,29 @@ class EventReplicatorWorker implements Runnable {
 
         // send events to Kafka and update progress topic in one transaction
         return kafkaTemplate.executeInTransaction(kafka -> {
-            String newLastLsn = null;
+            Cursor updatedLastCursor = null;
 
             for (var event : eventList) {
                 var id = (Long) event.get("id");
-                newLastLsn = event.get("lsn").toString();
+                var lsn = event.get("lsn").toString();
+
+                updatedLastCursor = new Cursor(lsn, id);
 
                 var key = event.get("key");
                 var data = (byte[]) event.get("data");
                 var metadata = (byte[]) event.get("metadata");
                 var timestamp = (Timestamp) event.get("timestamp");
-                var headers = toHeaders(id, newLastLsn, metadata);
+                var headers = toHeaders(id, lsn, metadata);
 
                 // send event to Kafka topic
                 kafka.send(new ProducerRecord<>(topic, null, timestamp.getTime(), serializeKey(key), data, headers));
             }
 
             // update progress topic
-            kafka.send(EventReplicator.PROGRESS_TOPIC, stringToBytes(replicatedTopic), stringToBytes(newLastLsn));
+            kafka.send(EventReplicator.PROGRESS_TOPIC, stringToBytes(replicatedTopic),
+                    stringToBytes(updatedLastCursor.toProgressValue()));
 
-            return newLastLsn;
+            return updatedLastCursor;
         });
     }
 
@@ -230,9 +241,58 @@ class EventReplicatorWorker implements Runnable {
      */
     private double computeLag() {
         var lag = jdbcTemplate.queryForObject(
-                SELECT_LAG_SQL.formatted(lastLsn, eventSchema, replicatedTopic),
+                SELECT_LAG_SQL.formatted(lastCursor.lsn(), eventSchema, replicatedTopic),
                 Long.class);
 
         return lag != null ? lag : 0;
+    }
+
+    /**
+     * Replication cursor pointing at the last successfully replicated row.
+     *
+     * <p>
+     * Persisted to the progress Kafka topic as {@code "<lsn>:<id>"}. The pair is
+     * compared via Postgres row-value semantics so consumers resume correctly
+     * across same-LSN siblings produced by a single transaction.
+     *
+     * @param lsn the row's commit LSN in canonical Postgres text form (e.g.
+     *            {@code "0/12A4B5C"})
+     * @param id  the row's bigserial identifier
+     */
+    record Cursor(String lsn, long id) {
+        /**
+         * Initial cursor value used for a topic with no recorded progress.
+         */
+        static final Cursor INITIAL = new Cursor("0/0", 0L);
+
+        /**
+         * Encodes this cursor for the progress Kafka topic.
+         * 
+         * @return canonical {@code "<lsn>:<id>"} text form of this cursor
+         */
+        String toProgressValue() {
+            return lsn + ":" + id;
+        }
+
+        /**
+         * Decodes a cursor from a progress-topic value.
+         * 
+         * @param value progress-topic value in the {@code "<lsn>:<id>"} form
+         * 
+         * @return cursor decoded from {@code value}
+         * 
+         * @throws IllegalStateException if the value is not in the expected
+         *                               {@code "<lsn>:<id>"} form
+         */
+        static Cursor fromProgressValue(String value) {
+            var parts = value.split(":");
+
+            if (parts.length != 2) {
+                throw new IllegalStateException(
+                        "Invalid progress-topic cursor value (expected 'lsn:id'): " + value);
+            }
+
+            return new Cursor(parts[0], Long.parseLong(parts[1]));
+        }
     }
 }

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorIT.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Dariusz Szpakowski
+ * Copyright (c) 2023-2026, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -73,6 +73,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import tech.kage.event.replicator.entity.EventReplicatorWorker.Cursor;
 
 /**
  * Integration tests for {@link EventReplicator}.
@@ -115,7 +116,7 @@ class EventReplicatorIT {
     @MockitoBean
     TaskScheduler taskScheduler;
 
-    Map<String, String> topicLastLsns;
+    Map<String, Cursor> topicLastCursors;
 
     @Container
     @ServiceConnection
@@ -133,16 +134,16 @@ class EventReplicatorIT {
 
     @BeforeEach
     void setUp(@Value("classpath:/test-data/events/ddl.sql") Resource ddl) throws IOException {
-        topicLastLsns = IntStream
+        topicLastCursors = IntStream
                 .rangeClosed(1, 10)
                 .boxed()
                 .map(id -> Map.entry(
                         "test_" + id + System.currentTimeMillis() + "_events",
-                        "0/" + Integer.toHexString(id)))
+                        new Cursor("0/" + Integer.toHexString(id), id.longValue())))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // create source event tables
-        for (var topic : topicLastLsns.keySet()) {
+        for (var topic : topicLastCursors.keySet()) {
             jdbcTemplate.execute(
                     ddl.getContentAsString(StandardCharsets.UTF_8)
                             .replace("<<topic_name>>", topic)
@@ -153,7 +154,7 @@ class EventReplicatorIT {
     @AfterEach
     void tearDown() {
         // drop source event tables
-        for (var topic : topicLastLsns.keySet()) {
+        for (var topic : topicLastCursors.keySet()) {
             jdbcTemplate.execute("drop table events." + topic);
         }
     }
@@ -169,7 +170,7 @@ class EventReplicatorIT {
                 pollInterval, true);
 
         // Then
-        assertThatCode(() -> kafkaAdmin.describeTopics(topicLastLsns.keySet().toArray(String[]::new)))
+        assertThatCode(() -> kafkaAdmin.describeTopics(topicLastCursors.keySet().toArray(String[]::new)))
                 .doesNotThrowAnyException();
     }
 
@@ -179,7 +180,7 @@ class EventReplicatorIT {
         // Given
         given(lockManager.acquireLock()).willReturn(true);
 
-        var expectedScheduledTasksCount = topicLastLsns.size() + 1; // include lock monitor
+        var expectedScheduledTasksCount = topicLastCursors.size() + 1; // include lock monitor
         var expectedDelay = Duration.ofMillis(pollInterval);
 
         // When
@@ -205,23 +206,23 @@ class EventReplicatorIT {
 
         // store initial progress
         kafkaTemplate.executeInTransaction(kafkaTransaction -> {
-            for (var topicEntry : topicLastLsns.entrySet()) {
+            for (var topicEntry : topicLastCursors.entrySet()) {
                 kafkaTransaction.send(
                         PROGRESS_TOPIC,
                         stringToBytes(topicEntry.getKey()),
-                        stringToBytes(topicEntry.getValue()));
+                        stringToBytes(topicEntry.getValue().toProgressValue()));
             }
 
             return 0;
         });
 
-        var expectedTopicLastLsns = topicLastLsns
+        var expectedTopicLastCursors = topicLastCursors
                 .entrySet()
                 .stream()
                 .map(topicEntry -> new Tuple(topicEntry.getKey(), topicEntry.getValue()))
                 .toList();
 
-        var expectedScheduledTasksCount = topicLastLsns.size() + 1; // include lock monitor
+        var expectedScheduledTasksCount = topicLastCursors.size() + 1; // include lock monitor
         var expectedDelay = Duration.ofMillis(pollInterval);
 
         // When
@@ -243,12 +244,40 @@ class EventReplicatorIT {
 
         assertThat(testedTasks)
                 .describedAs("scheduled tasks")
-                .extracting("replicatedTopic", "lastLsn")
-                .containsExactlyInAnyOrderElementsOf(expectedTopicLastLsns);
+                .extracting("replicatedTopic", "lastCursor")
+                .containsExactlyInAnyOrderElementsOf(expectedTopicLastCursors);
     }
 
     @Test
     @Order(4)
+    void throwsExceptionWhenProgressTopicHasMalformedValue() {
+        // Given
+        given(lockManager.acquireLock()).willReturn(true);
+
+        var someTopic = topicLastCursors.keySet().iterator().next();
+
+        kafkaTemplate.executeInTransaction(kafkaTransaction -> {
+            kafkaTransaction.send(PROGRESS_TOPIC, stringToBytes(someTopic), stringToBytes("malformed-no-colon"));
+
+            return 0;
+        });
+
+        // When
+        var thrown = assertThrows(
+                Throwable.class,
+                () -> eventReplicator.init(kafkaAdmin, jdbcTemplate, lockManager, consumerFactory, meterRegistry,
+                        environment, pollInterval, true));
+
+        // Then
+        assertThat(thrown)
+                .describedAs("thrown exception")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid progress-topic cursor value")
+                .hasMessageContaining("malformed-no-colon");
+    }
+
+    @Test
+    @Order(5)
     void throwsExceptionWhenProgressTopicIsFilled(
             @Value("${spring.kafka.consumer.max-poll-records}") int kafkaConsumerMaxPollRecords) {
         // Given
@@ -257,7 +286,7 @@ class EventReplicatorIT {
         // progress topic is filled
         kafkaTemplate.executeInTransaction(kafkaTransaction -> {
             for (var i = 0; i <= kafkaConsumerMaxPollRecords; i++) {
-                kafkaTransaction.send(PROGRESS_TOPIC, stringToBytes("test_topic"), stringToBytes("0/0"));
+                kafkaTransaction.send(PROGRESS_TOPIC, stringToBytes("test_topic"), stringToBytes("0/0:0"));
             }
 
             return 0;
@@ -277,7 +306,7 @@ class EventReplicatorIT {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void throwsExceptionWhenLockCannotBeAcquired() {
         // Given
         given(lockManager.acquireLock()).willReturn(false);

--- a/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorWorkerIT.java
+++ b/tech.kage.event.replicator/src/test/java/tech/kage/event/replicator/entity/EventReplicatorWorkerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Dariusz Szpakowski
+ * Copyright (c) 2023-2026, Dariusz Szpakowski
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,8 @@ package tech.kage.event.replicator.entity;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static tech.kage.event.EventStore.SOURCE_ID;
 import static tech.kage.event.EventStore.SOURCE_LSN;
 import static tech.kage.event.replicator.entity.EventReplicator.PROGRESS_TOPIC;
@@ -69,6 +71,7 @@ import org.testcontainers.kafka.KafkaContainer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import tech.kage.event.crypto.MetadataSerializer;
+import tech.kage.event.replicator.entity.EventReplicatorWorker.Cursor;
 
 /**
  * Integration tests for {@link EventReplicatorWorker}.
@@ -128,10 +131,10 @@ abstract class EventReplicatorWorkerIT<K> {
     @Test
     void copiesEventsFromDatabaseToKafkaInSinglePoll() {
         // Given
-        var lastLsn = "0/0";
+        var lastCursor = Cursor.INITIAL;
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastCursor);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, maxPollRows - 1)
@@ -173,10 +176,10 @@ abstract class EventReplicatorWorkerIT<K> {
     @Test
     void copiesEventsFromDatabaseToKafkaInMultiplePolls() {
         // Given
-        var lastLsn = "0/0";
+        var lastCursor = Cursor.INITIAL;
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastCursor);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, maxPollRows + 1)
@@ -216,12 +219,72 @@ abstract class EventReplicatorWorkerIT<K> {
     }
 
     @Test
-    void resumesCopyingEventsFromGivenLsn() {
+    void copiesEventsSharingLsnFromDatabaseToKafkaInMultiplePolls() {
         // Given
-        var lastLsn = "0/5";
+        // A multi-event transaction produces several rows that all share one
+        // commit LSN once LsnUpdater has stamped them. Here we simulate the
+        // post-stamping state by inserting rows with a fixed lsn.
+        // batchSize is set below the row count so the worker has to resume
+        // past same-LSN siblings — only the (lsn, id) cursor allows that.
+        var sharedLsn = "0/100";
+        var batchSize = 2;
+        var rowCount = batchSize + 1;
+
+        var sourceEvents = IntStream
+                .rangeClosed(1, rowCount)
+                .boxed()
+                .map(id -> {
+                    var base = testEvent(id);
+                    return new EventData(
+                            base.id(), base.key(), base.data(), base.metadata(), base.timestamp(), sharedLsn);
+                })
+                .toList();
+
+        for (var event : sourceEvents) {
+            insertEvent(topic, event);
+        }
+
+        var batchEnv = mock(Environment.class);
+        given(batchEnv.getProperty("event.replicator.poll.max.rows", Integer.class, 100))
+                .willReturn(batchSize);
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+                jdbcTemplate, kafkaTemplate, meterRegistry, batchEnv, eventSchema, topic, Cursor.INITIAL);
+
+        // When
+        worker.run();
+
+        // Then
+        var replicatedEvents = readRecordsFromKafka(topic);
+
+        assertThat(replicatedEvents)
+                .describedAs("replicated events")
+                .zipSatisfy(sourceEvents, (replicatedEvent, sourceEvent) -> {
+                    assertThat(replicatedEvent.key())
+                            .describedAs("replicated event key")
+                            .isEqualTo(keyToBytes(sourceEvent.key()));
+
+                    assertThat(replicatedEvent.value())
+                            .describedAs("replicated event data")
+                            .isEqualTo(sourceEvent.data());
+
+                    assertThat(replicatedEvent.timestamp())
+                            .describedAs("replicated event timestamp")
+                            .isEqualTo(sourceEvent.timestamp().toEpochMilli());
+
+                    assertThat(replicatedEvent.headers())
+                            .describedAs("replicated event headers")
+                            .isEqualTo(expectedHeaders(sourceEvent));
+                });
+    }
+
+    @Test
+    void resumesCopyingEventsFromGivenCursor() {
+        // Given
+        var lastCursor = new Cursor("0/5", 5L);
+
+        var worker = new EventReplicatorWorker(
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastCursor);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, 11)
@@ -263,13 +326,13 @@ abstract class EventReplicatorWorkerIT<K> {
     }
 
     @Test
-    void storesLastReplicatedEventLsn() {
+    void storesLastReplicatedEventCursor() {
         // Given
-        var lastLsn = "0/8";
-        var expectedLastLsn = "0/17"; // 23 in hex
+        var lastCursor = new Cursor("0/8", 8L);
+        var expectedLastCursor = "0/17:23"; // lsn 0/17 (23 hex), id 23
 
         var worker = new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastCursor);
 
         var sourceEvents = IntStream
                 .rangeClosed(1, 23)
@@ -285,25 +348,25 @@ abstract class EventReplicatorWorkerIT<K> {
         worker.run();
 
         // Then
-        String storedLastLsn = null;
+        String storedLastCursor = null;
 
         var progressRecords = readRecordsFromKafka(PROGRESS_TOPIC);
 
         for (var consumerRecord : progressRecords) {
             if (topic.contains(stringFromBytes(consumerRecord.key()))) {
-                storedLastLsn = stringFromBytes(consumerRecord.value());
+                storedLastCursor = stringFromBytes(consumerRecord.value());
             }
         }
 
-        assertThat(storedLastLsn)
-                .describedAs("stored last LSN")
-                .isEqualTo(expectedLastLsn);
+        assertThat(storedLastCursor)
+                .describedAs("stored last cursor")
+                .isEqualTo(expectedLastCursor);
     }
 
     @Test
     void monitorsReplicationLag() {
         // Given
-        var lastLsn = "0/5";
+        var lastCursor = new Cursor("0/5", 5L);
         var expectedReplicationLag = 8;
 
         var sourceEvents = IntStream
@@ -317,7 +380,8 @@ abstract class EventReplicatorWorkerIT<K> {
         }
 
         // When
-        new EventReplicatorWorker(jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+        new EventReplicatorWorker(jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic,
+                lastCursor);
 
         // Then
         var replicationLag = meterRegistry.find("event.replicator.lag").tag("topic", topic).gauge().value();
@@ -330,11 +394,11 @@ abstract class EventReplicatorWorkerIT<K> {
     @Test
     void reportsZeroLagWhenNoEventsHaveLsn() {
         // Given
-        var lastLsn = "0/0";
+        var lastCursor = Cursor.INITIAL;
 
         // When
         new EventReplicatorWorker(
-                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastLsn);
+                jdbcTemplate, kafkaTemplate, meterRegistry, environment, eventSchema, topic, lastCursor);
 
         // Then
         var replicationLag = meterRegistry.find("event.replicator.lag").tag("topic", topic).gauge().value();


### PR DESCRIPTION
## Summary

The WAL LSN-based event replication added in #43 silently dropped rows under two correctness gaps. This PR closes both.

## Gap 1 — wrong LSN value

`LsnUpdater` stamped each row with `replicationStream.getLastReceiveLSN()` at the moment it parsed the INSERT message. That is the WAL position of the INSERT record, not the commit LSN.

INSERT WAL positions are themselves strictly monotonic (Postgres uses a single global WAL log), but `pgoutput` delivers transactions to the consumer in **commit order**, not WAL-write order. So with concurrent writers — txn A's INSERT at WAL=100, then txn B's INSERT at WAL=110, then B commits at 120, then A commits at 130 — the consumer sees B's INSERT before A's INSERT, and the per-INSERT LSN values stamped on the rows go *down* across the two transactions.

A consumer using `WHERE lsn > :cursor` would advance its cursor to 110 (after seeing B), then permanently skip A's row at 100. **Lost row.**

**Fix.** Stamp every INSERT in a transaction with `BEGIN.final_lsn`. In `pgoutput` v1 with non-streaming, the walsender buffers the entire transaction and only emits messages after reading the COMMIT record, so `final_lsn` is already the commit LSN by the time the consumer sees BEGIN. All rows in one transaction now share one LSN, and that LSN is monotonic across transactions.

## Gap 2 — lsn-only cursor cannot resume mid-batch

Once Gap 1 is fixed, every row in one transaction shares the same commit LSN. `EventReplicatorWorker` reads with `LIMIT N`, so a transaction that produces more than `N` rows gets split: the first batch advances the cursor to `L`, the next batch's `lsn > L` filter then silently skips the remaining same-LSN siblings. Multi-event-per-transaction is a valid usage of `EventStore.save()` — downstream callers can compose multiple `save()` Monos under one `TransactionalOperator` — so this would hit in normal operation, not only on crash.

**Fix.** Cursor key becomes `(lsn, id)`, compared via Postgres row-value semantics. `bigserial` is monotonic within one transaction and `pgoutput` emits a transaction's INSERTs in WAL/exec order, so id order within a same-LSN group is reliable.

## Implementation

### `tech.kage.event.postgres.lsnupdater`

- **`PgOutputMessageParser`** — replaced the `MessageType` enum + nullable `MessageInfo` record with a sealed `PgOutputMessage` interface and four records (`BeginMessage`, `CommitMessage`, `RelationMessage`, `InsertMessage`). Added wire-format parsing for BEGIN and COMMIT.
- **`LsnUpdater`** — tracks `currentTxnLsn` (set on BEGIN, cleared on COMMIT, used to stamp every INSERT in between). Drops the call to `replicationStream.getLastReceiveLSN()` from the per-row stamping path. Added `lsnToText` to format a 64-bit LSN as Postgres' canonical `"X/Y"`. Per-message `setFlushedLSN` advance is unchanged — pgoutput v1 buffers per-txn at the walsender, so partial-txn loss can't happen, and crash resume re-receives the same BEGIN with the same `final_lsn` (idempotent).

### `tech.kage.event.replicator`

- **`EventReplicatorWorker`** — replaced `String lastLsn` with a `Cursor(String lsn, long id)` record. SELECT now uses `(lsn, id) > ('X/Y'::pg_lsn, N) ORDER BY lsn, id LIMIT M`.
- **Progress-topic encoding** — value format changed from `"X/Y"` to `"X/Y:N"`. Decoded via `Cursor.fromProgressValue`, encoded via `Cursor.toProgressValue`. Initial cursor is `Cursor.INITIAL` (`0/0`, `0`). No backward-compat fallback — see upgrade notes.
- **`EventReplicator`** — `readLastCursors` returns `Map<String, Cursor>`.

## Upgrade notes

The Kafka progress-topic value format changed from `"X/Y"` to `"X/Y:N"`. There is no backward-compat parse path. **On upgrade, operators must wipe the `_event_replicator_progress` topic**. Replication will resume from the beginning of each event table on first run after the wipe.

No schema change to `events.<topic>_events`. The existing single-column `(lsn)` btree index is sufficient for the new `(lsn, id) > ...` queries — same-LSN groups are small, and Postgres uses the index for lsn ordering then filters `id` post-fetch.

## Out of scope

- Handling pgoutput v2+ streaming (`STREAM START`/`STREAM COMMIT`). Current slot uses `proto_version=1`; if that ever changes, BEGIN/COMMIT-based stamping needs revisiting because streamed transactions emit messages before commit.